### PR TITLE
Feature: Androidでも再生を止めずにhttpHeaderだけ差し替えられるようにする

### DIFF
--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -102,6 +102,13 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
 
   @override
   Future<void> stopPictureInPicture() async {}
+
+  @override
+  Future<void> replaceDataSource({
+    String? dataSource,
+    Map<String, String>? httpHeaders,
+    VideoFormat? formatHint,
+  }) async {}
 }
 
 Future<ClosedCaptionFile> _loadClosedCaption() async =>

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -16,6 +16,10 @@ import io.flutter.plugin.common.StandardMessageCodec;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /** Generated class from Pigeon. */
@@ -596,6 +600,163 @@ public class Messages {
     }
   }
 
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static final class ReplaceDataSourceMessage {
+    private @NonNull Long textureId;
+
+    public @NonNull Long getTextureId() {
+      return textureId;
+    }
+
+    public void setTextureId(@NonNull Long setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"textureId\" is null.");
+      }
+      this.textureId = setterArg;
+    }
+
+    private @Nullable String asset;
+
+    public @Nullable String getAsset() {
+      return asset;
+    }
+
+    public void setAsset(@Nullable String setterArg) {
+      this.asset = setterArg;
+    }
+
+    private @Nullable String uri;
+
+    public @Nullable String getUri() {
+      return uri;
+    }
+
+    public void setUri(@Nullable String setterArg) {
+      this.uri = setterArg;
+    }
+
+    private @Nullable String packageName;
+
+    public @Nullable String getPackageName() {
+      return packageName;
+    }
+
+    public void setPackageName(@Nullable String setterArg) {
+      this.packageName = setterArg;
+    }
+
+    private @Nullable String formatHint;
+
+    public @Nullable String getFormatHint() {
+      return formatHint;
+    }
+
+    public void setFormatHint(@Nullable String setterArg) {
+      this.formatHint = setterArg;
+    }
+
+    private @NonNull Map<String, String> httpHeaders;
+
+    public @NonNull Map<String, String> getHttpHeaders() {
+      return httpHeaders;
+    }
+
+    public void setHttpHeaders(@NonNull Map<String, String> setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"httpHeaders\" is null.");
+      }
+      this.httpHeaders = setterArg;
+    }
+
+    /** Constructor is non-public to enforce null safety; use Builder. */
+    ReplaceDataSourceMessage() {}
+
+    public static final class Builder {
+
+      private @Nullable Long textureId;
+
+      public @NonNull Builder setTextureId(@NonNull Long setterArg) {
+        this.textureId = setterArg;
+        return this;
+      }
+
+      private @Nullable String asset;
+
+      public @NonNull Builder setAsset(@Nullable String setterArg) {
+        this.asset = setterArg;
+        return this;
+      }
+
+      private @Nullable String uri;
+
+      public @NonNull Builder setUri(@Nullable String setterArg) {
+        this.uri = setterArg;
+        return this;
+      }
+
+      private @Nullable String packageName;
+
+      public @NonNull Builder setPackageName(@Nullable String setterArg) {
+        this.packageName = setterArg;
+        return this;
+      }
+
+      private @Nullable String formatHint;
+
+      public @NonNull Builder setFormatHint(@Nullable String setterArg) {
+        this.formatHint = setterArg;
+        return this;
+      }
+
+      private @Nullable Map<String, String> httpHeaders;
+
+      public @NonNull Builder setHttpHeaders(@NonNull Map<String, String> setterArg) {
+        this.httpHeaders = setterArg;
+        return this;
+      }
+
+      public @NonNull ReplaceDataSourceMessage build() {
+        ReplaceDataSourceMessage pigeonReturn = new ReplaceDataSourceMessage();
+        pigeonReturn.setTextureId(textureId);
+        pigeonReturn.setAsset(asset);
+        pigeonReturn.setUri(uri);
+        pigeonReturn.setPackageName(packageName);
+        pigeonReturn.setFormatHint(formatHint);
+        pigeonReturn.setHttpHeaders(httpHeaders);
+        return pigeonReturn;
+      }
+    }
+
+    @NonNull
+    ArrayList<Object> toList() {
+      ArrayList<Object> toListResult = new ArrayList<Object>(6);
+      toListResult.add(textureId);
+      toListResult.add(asset);
+      toListResult.add(uri);
+      toListResult.add(packageName);
+      toListResult.add(formatHint);
+      toListResult.add(httpHeaders);
+      return toListResult;
+    }
+
+    static @NonNull ReplaceDataSourceMessage fromList(@NonNull ArrayList<Object> list) {
+      ReplaceDataSourceMessage pigeonResult = new ReplaceDataSourceMessage();
+      Object textureId = list.get(0);
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      Object asset = list.get(1);
+      pigeonResult.setAsset((String) asset);
+      Object uri = list.get(2);
+      pigeonResult.setUri((String) uri);
+      Object packageName = list.get(3);
+      pigeonResult.setPackageName((String) packageName);
+      Object formatHint = list.get(4);
+      pigeonResult.setFormatHint((String) formatHint);
+      Object httpHeaders = list.get(5);
+      pigeonResult.setHttpHeaders((Map<String, String>) httpHeaders);
+      return pigeonResult;
+    }
+  }
+
   private static class AndroidVideoPlayerApiCodec extends StandardMessageCodec {
     public static final AndroidVideoPlayerApiCodec INSTANCE = new AndroidVideoPlayerApiCodec();
 
@@ -615,8 +776,10 @@ public class Messages {
         case (byte) 132:
           return PositionMessage.fromList((ArrayList<Object>) readValue(buffer));
         case (byte) 133:
-          return TextureMessage.fromList((ArrayList<Object>) readValue(buffer));
+          return ReplaceDataSourceMessage.fromList((ArrayList<Object>) readValue(buffer));
         case (byte) 134:
+          return TextureMessage.fromList((ArrayList<Object>) readValue(buffer));
+        case (byte) 135:
           return VolumeMessage.fromList((ArrayList<Object>) readValue(buffer));
         default:
           return super.readValueOfType(type, buffer);
@@ -640,11 +803,14 @@ public class Messages {
       } else if (value instanceof PositionMessage) {
         stream.write(132);
         writeValue(stream, ((PositionMessage) value).toList());
-      } else if (value instanceof TextureMessage) {
+      } else if (value instanceof ReplaceDataSourceMessage) {
         stream.write(133);
+        writeValue(stream, ((ReplaceDataSourceMessage) value).toList());
+      } else if (value instanceof TextureMessage) {
+        stream.write(134);
         writeValue(stream, ((TextureMessage) value).toList());
       } else if (value instanceof VolumeMessage) {
-        stream.write(134);
+        stream.write(135);
         writeValue(stream, ((VolumeMessage) value).toList());
       } else {
         super.writeValue(stream, value);
@@ -678,6 +844,8 @@ public class Messages {
     void pause(@NonNull TextureMessage msg);
 
     void setMixWithOthers(@NonNull MixWithOthersMessage msg);
+
+    void replaceDataSource(@NonNull ReplaceDataSourceMessage msg);
 
     /** The codec used by AndroidVideoPlayerApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -933,6 +1101,29 @@ public class Messages {
                 MixWithOthersMessage msgArg = (MixWithOthersMessage) args.get(0);
                 try {
                   api.setMixWithOthers(msgArg);
+                  wrapped.add(0, null);
+                } catch (Throwable exception) {
+                  ArrayList<Object> wrappedError = wrapError(exception);
+                  wrapped = wrappedError;
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.AndroidVideoPlayerApi.replaceDataSource", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                ReplaceDataSourceMessage msgArg = (ReplaceDataSourceMessage) args.get(0);
+                try {
+                  api.replaceDataSource(msgArg);
                   wrapped.add(0, null);
                 } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -292,6 +292,12 @@ final class VideoPlayer {
     return exoPlayer.getCurrentPosition();
   }
 
+  void setHttpHeaders(Map<String, String> headers) {
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      httpDataSourceFactory.getDefaultRequestProperties().set(entry.getKey(), entry.getValue());
+    }
+  }
+
   @SuppressWarnings("SuspiciousNameCombination")
   @VisibleForTesting
   void sendInitialized() {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -19,6 +19,7 @@ import io.flutter.plugins.videoplayer.Messages.LoopingMessage;
 import io.flutter.plugins.videoplayer.Messages.MixWithOthersMessage;
 import io.flutter.plugins.videoplayer.Messages.PlaybackSpeedMessage;
 import io.flutter.plugins.videoplayer.Messages.PositionMessage;
+import io.flutter.plugins.videoplayer.Messages.ReplaceDataSourceMessage;
 import io.flutter.plugins.videoplayer.Messages.TextureMessage;
 import io.flutter.plugins.videoplayer.Messages.VolumeMessage;
 import io.flutter.view.TextureRegistry;
@@ -212,6 +213,18 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     options.mixWithOthers = arg.getMixWithOthers();
   }
 
+  public void replaceDataSource(@NonNull ReplaceDataSourceMessage arg) {
+    VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    String uri = arg.getUri();
+
+    if (uri != null) {
+      Map<String, String> httpHeaders = arg.getHttpHeaders();
+      player.setHttpHeaders(httpHeaders);
+    } else {
+      // error
+    }
+  }
+  
   private interface KeyForAssetFn {
     String get(String asset);
   }

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -189,4 +189,14 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       Duration(milliseconds: pair[1] as int),
     );
   }
+
+  @override
+  Future<void> replaceDataSource(int textureId, DataSource dataSource) {
+    return _api.replaceDataSource(ReplaceDataSourceMessage(
+      textureId: textureId,
+      uri: dataSource.uri,
+      httpHeaders: dataSource.httpHeaders,
+      // TODO: other fields
+    ));
+  }
 }

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -199,6 +199,52 @@ class MixWithOthersMessage {
   }
 }
 
+class ReplaceDataSourceMessage {
+  ReplaceDataSourceMessage({
+    required this.textureId,
+    this.asset,
+    this.uri,
+    this.packageName,
+    this.formatHint,
+    required this.httpHeaders,
+  });
+
+  int textureId;
+
+  String? asset;
+
+  String? uri;
+
+  String? packageName;
+
+  String? formatHint;
+
+  Map<String?, String?> httpHeaders;
+
+  Object encode() {
+    return <Object?>[
+      textureId,
+      asset,
+      uri,
+      packageName,
+      formatHint,
+      httpHeaders,
+    ];
+  }
+
+  static ReplaceDataSourceMessage decode(Object result) {
+    result as List<Object?>;
+    return ReplaceDataSourceMessage(
+      textureId: result[0]! as int,
+      asset: result[1] as String?,
+      uri: result[2] as String?,
+      packageName: result[3] as String?,
+      formatHint: result[4] as String?,
+      httpHeaders: (result[5] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+    );
+  }
+}
+
 class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
   const _AndroidVideoPlayerApiCodec();
   @override
@@ -218,11 +264,14 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
     } else if (value is PositionMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is TextureMessage) {
+    } else if (value is ReplaceDataSourceMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeMessage) {
+    } else if (value is TextureMessage) {
       buffer.putUint8(134);
+      writeValue(buffer, value.encode());
+    } else if (value is VolumeMessage) {
+      buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -243,8 +292,10 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
       case 132:
         return PositionMessage.decode(readValue(buffer)!);
       case 133:
-        return TextureMessage.decode(readValue(buffer)!);
+        return ReplaceDataSourceMessage.decode(readValue(buffer)!);
       case 134:
+        return TextureMessage.decode(readValue(buffer)!);
+      case 135:
         return VolumeMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -494,6 +545,28 @@ class AndroidVideoPlayerApi {
   Future<void> setMixWithOthers(MixWithOthersMessage arg_msg) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.AndroidVideoPlayerApi.setMixWithOthers', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_msg]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> replaceDataSource(ReplaceDataSourceMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.AndroidVideoPlayerApi.replaceDataSource', codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
         await channel.send(<Object?>[arg_msg]) as List<Object?>?;

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -56,6 +56,16 @@ class MixWithOthersMessage {
   bool mixWithOthers;
 }
 
+class ReplaceDataSourceMessage {
+  ReplaceDataSourceMessage(this.textureId, this.asset, this.uri, this.packageName, this.formatHint, this.httpHeaders);
+  int textureId;
+  String? asset;
+  String? uri;
+  String? packageName;
+  String? formatHint;
+  Map<String?, String?> httpHeaders;
+}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class AndroidVideoPlayerApi {
   void initialize();
@@ -69,4 +79,5 @@ abstract class AndroidVideoPlayerApi {
   void seekTo(PositionMessage msg);
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
+  void replaceDataSource(ReplaceDataSourceMessage msg);
 }

--- a/packages/video_player/video_player_android/test/test_api.g.dart
+++ b/packages/video_player/video_player_android/test/test_api.g.dart
@@ -32,11 +32,14 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
     } else if (value is PositionMessage) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is TextureMessage) {
+    } else if (value is ReplaceDataSourceMessage) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeMessage) {
+    } else if (value is TextureMessage) {
       buffer.putUint8(134);
+      writeValue(buffer, value.encode());
+    } else if (value is VolumeMessage) {
+      buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -57,8 +60,10 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       case 132:
         return PositionMessage.decode(readValue(buffer)!);
       case 133:
-        return TextureMessage.decode(readValue(buffer)!);
+        return ReplaceDataSourceMessage.decode(readValue(buffer)!);
       case 134:
+        return TextureMessage.decode(readValue(buffer)!);
+      case 135:
         return VolumeMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -92,6 +97,8 @@ abstract class TestHostVideoPlayerApi {
   void pause(TextureMessage msg);
 
   void setMixWithOthers(MixWithOthersMessage msg);
+
+  void replaceDataSource(ReplaceDataSourceMessage msg);
 
   static void setup(TestHostVideoPlayerApi? api,
       {BinaryMessenger? binaryMessenger}) {
@@ -330,6 +337,29 @@ abstract class TestHostVideoPlayerApi {
           assert(arg_msg != null,
               'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.setMixWithOthers was null, expected non-null MixWithOthersMessage.');
           api.setMixWithOthers(arg_msg!);
+          return <Object?>[];
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.AndroidVideoPlayerApi.replaceDataSource', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.replaceDataSource was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final ReplaceDataSourceMessage? arg_msg =
+              (args[0] as ReplaceDataSourceMessage?);
+          assert(arg_msg != null,
+              'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.replaceDataSource was null, expected non-null ReplaceDataSourceMessage.');
+          api.replaceDataSource(arg_msg!);
           return <Object?>[];
         });
       }


### PR DESCRIPTION
## 背景
HLS＋CloudFrontでプライベート動画配信を行う場合、ライブ配信の再生を止めずにアクセストークンを更新したい場面がある。iOSでは実装済みだったが、Androidでは未実装だった。

## 変更点
`HttpDataSource`と`MediaSource `の間に`ResolvingDataSource `を挟み、リクエストごとにhttpHeaderを変更できるようにした。

### 他に試したこと
- `httpDataSourceFactory.defaultRequestProperties.set("Cookie", ...)`はすでに再生が始まっているプレイヤーには影響を及ぼさなかった。
`mediaSource`や`exoPlayer`のインスタンスを新しく作り直すと再生状態がリセットされてしまった。

## やっていないこと
`replaceDataSource`に定義されている`httpHeader`以外のプロパティを変更すること。`uri`が現在の状態と一致しているかの確認もしていない。



