### PR TITLE
fix: prevent updating values after dispose

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -829,6 +829,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   void _updatePosition(Duration position) {
+    if (_isDisposed) return;
+
     value = value.copyWith(
       position: position,
       caption: _getCaptionAt(position),


### PR DESCRIPTION
`seekTo` など、非同期なメソッドの内部でawaitがdisposeを跨いで実行されると、dispose後に`value`を更新しようとしてエラーになる