### PR TITLE
fix: typo eventSync tag name

### DIFF
--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -371,7 +371,7 @@ NS_INLINE UIViewController *rootViewController(void) {
     (AVPictureInPictureController *)pictureInPictureController {
   self.isPictureInPictureStarted = YES;
   if (_eventSink != nil) {
-    _eventSink(@{@"event" : @"startingPictureInPicture"});
+    _eventSink(@{@"event" : @"startedPictureInPicture"});
   }
   [self updatePlayingState];
 }


### PR DESCRIPTION
iOSのPip開始時にeventSinkに流すイベントのタグが間違えていたのでFlutterにイベントが届いていなかった