### PR TITLE
Fix: RemoteControlやPipから一時停止したとき、内部的にはプレイヤーが停止状態になっていない問題を修正

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -480,6 +480,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.isPlayingStateUpdate:
           value = value.copyWith(isPlaying: event.isPlaying);
           break;
+        case VideoEventType.play:
+          play();
+          break;
+        case VideoEventType.pause:
+          pause();
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -14,7 +14,15 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 import 'src/closed_caption_file.dart';
 
 export 'package:video_player_platform_interface/video_player_platform_interface.dart'
-    show DurationRange, DataSourceType, VideoFormat, VideoPlayerOptions, MuxConfig, MuxPageType, MuxVideoStreamType;
+    show
+        DurationRange,
+        DataSourceType,
+        VideoFormat,
+        VideoPlayerOptions,
+        MediaInfo,
+        MuxConfig,
+        MuxPageType,
+        MuxVideoStreamType;
 
 export 'src/closed_caption_file.dart';
 
@@ -263,11 +271,13 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   VideoPlayerController.asset(this.dataSource,
       {this.package,
       Future<ClosedCaptionFile>? closedCaptionFile,
-      this.videoPlayerOptions})
+      this.videoPlayerOptions,
+      this.mediaInfo})
       : _closedCaptionFileFuture = closedCaptionFile,
         dataSourceType = DataSourceType.asset,
         formatHint = null,
         httpHeaders = const <String, String>{},
+        isLiveStream = false,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a network video.
@@ -286,6 +296,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     Future<ClosedCaptionFile>? closedCaptionFile,
     this.videoPlayerOptions,
     this.httpHeaders = const <String, String>{},
+    this.mediaInfo,
+    required this.isLiveStream,
   })  : _closedCaptionFileFuture = closedCaptionFile,
         dataSourceType = DataSourceType.network,
         package = null,
@@ -306,6 +318,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     Future<ClosedCaptionFile>? closedCaptionFile,
     this.videoPlayerOptions,
     this.httpHeaders = const <String, String>{},
+    this.mediaInfo,
+    required this.isLiveStream,
   })  : _closedCaptionFileFuture = closedCaptionFile,
         dataSource = url.toString(),
         dataSourceType = DataSourceType.network,
@@ -319,12 +333,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   VideoPlayerController.file(File file,
       {Future<ClosedCaptionFile>? closedCaptionFile,
       this.videoPlayerOptions,
-      this.httpHeaders = const <String, String>{}})
+      this.httpHeaders = const <String, String>{},
+      this.mediaInfo})
       : _closedCaptionFileFuture = closedCaptionFile,
         dataSource = Uri.file(file.absolute.path).toString(),
         dataSourceType = DataSourceType.file,
         package = null,
         formatHint = null,
+        isLiveStream = false,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from a contentUri.
@@ -332,7 +348,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// This will load the video from the input content-URI.
   /// This is supported on Android only.
   VideoPlayerController.contentUri(Uri contentUri,
-      {Future<ClosedCaptionFile>? closedCaptionFile, this.videoPlayerOptions})
+      {Future<ClosedCaptionFile>? closedCaptionFile,
+      this.videoPlayerOptions,
+      this.mediaInfo})
       : assert(defaultTargetPlatform == TargetPlatform.android,
             'VideoPlayerController.contentUri is only supported on Android.'),
         _closedCaptionFileFuture = closedCaptionFile,
@@ -341,6 +359,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         package = null,
         formatHint = null,
         httpHeaders = const <String, String>{},
+        isLiveStream = false,
         super(const VideoPlayerValue(duration: Duration.zero));
 
   /// The URI to the video file. This will be in different formats depending on
@@ -365,6 +384,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// Only set for [asset] videos. The package that the asset was loaded from.
   final String? package;
+
+  /// iOSではコントロールセンター、AndroidではNotificationに表示されるメディア情報
+  final MediaInfo? mediaInfo;
+
+  ///
+  final bool isLiveStream;
 
   Future<ClosedCaptionFile>? _closedCaptionFileFuture;
   ClosedCaptionFile? _closedCaptionFile;
@@ -401,6 +426,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           sourceType: DataSourceType.asset,
           asset: dataSource,
           package: package,
+          mediaInfo: mediaInfo,
         );
         break;
       case DataSourceType.network:
@@ -409,6 +435,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           uri: dataSource,
           formatHint: formatHint,
           httpHeaders: httpHeaders,
+          mediaInfo: mediaInfo,
+          isLiveStream: isLiveStream,
         );
         break;
       case DataSourceType.file:
@@ -416,12 +444,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           sourceType: DataSourceType.file,
           uri: dataSource,
           httpHeaders: httpHeaders,
+          mediaInfo: mediaInfo,
         );
         break;
       case DataSourceType.contentUri:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.contentUri,
           uri: dataSource,
+          mediaInfo: mediaInfo,
         );
         break;
     }

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -276,6 +276,8 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.isPlayingStateUpdate:
           value = value.copyWith(isPlaying: event.isPlaying);
           break;
+        case VideoEventType.play:
+        case VideoEventType.pause:
         case VideoEventType.startedPictureInPicture:
         case VideoEventType.stoppedPictureInPicture:
         case VideoEventType.unknown:

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -183,6 +183,10 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
             eventType: VideoEventType.isPlayingStateUpdate,
             isPlaying: map['isPlaying'] as bool,
           );
+        case 'play':
+          return VideoEvent(eventType: VideoEventType.play);
+        case 'pause':
+          return VideoEvent(eventType: VideoEventType.pause);
         default:
           return VideoEvent(eventType: VideoEventType.unknown);
       }

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -289,6 +289,8 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.isPlayingStateUpdate:
           value = value.copyWith(isPlaying: event.isPlaying);
           break;
+        case VideoEventType.play:
+        case VideoEventType.pause:
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -65,13 +65,15 @@
 @property(nonatomic, readonly) BOOL disposed;
 @property(nonatomic, readonly) BOOL isPlaying;
 @property(nonatomic) BOOL isLooping;
+@property(nonatomic) BOOL isLiveStream;
 @property(nonatomic, readonly) BOOL isInitialized;
 @property(nonatomic) BOOL isPictureInPictureStarted;
 @property(nonatomic) AVPlayerTimeControlStatus lastAVPlayerTimeControlStatus;
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FLTFrameUpdater *)frameUpdater
                 httpHeaders:(nonnull NSDictionary<NSString *, NSString *> *)headers
-              playerFactory:(id<FVPPlayerFactory>)playerFactory;
+              playerFactory:(id<FVPPlayerFactory>)playerFactory
+               isLiveStream:(BOOL)isLiveStream;
 @end
 
 static void *timeRangeContext = &timeRangeContext;
@@ -91,7 +93,8 @@ static void *rateContext = &rateContext;
   return [self initWithURL:[NSURL fileURLWithPath:path]
               frameUpdater:frameUpdater
                httpHeaders:@{}
-             playerFactory:playerFactory];
+             playerFactory:playerFactory
+             isLiveStream:NO];
 }
 
 - (void)addObserversForItem:(AVPlayerItem *)item player:(AVPlayer *)player {
@@ -239,24 +242,28 @@ NS_INLINE UIViewController *rootViewController(void) {
 - (instancetype)initWithURL:(NSURL *)url
                frameUpdater:(FLTFrameUpdater *)frameUpdater
                 httpHeaders:(nonnull NSDictionary<NSString *, NSString *> *)headers
-              playerFactory:(id<FVPPlayerFactory>)playerFactory {
+              playerFactory:(id<FVPPlayerFactory>)playerFactory
+               isLiveStream:(BOOL)isLiveStream {
   NSDictionary<NSString *, id> *options = nil;
   if ([headers count] != 0) {
     options = @{@"AVURLAssetHTTPHeaderFieldsKey" : headers};
   }
   AVURLAsset *urlAsset = [AVURLAsset URLAssetWithURL:url options:options];
   AVPlayerItem *item = [AVPlayerItem playerItemWithAsset:urlAsset];
-  return [self initWithPlayerItem:item frameUpdater:frameUpdater playerFactory:playerFactory];
+  return [self initWithPlayerItem:item frameUpdater:frameUpdater playerFactory:playerFactory isLiveStream:isLiveStream];
 }
 
 - (instancetype)initWithPlayerItem:(AVPlayerItem *)item
                       frameUpdater:(FLTFrameUpdater *)frameUpdater
-                     playerFactory:(id<FVPPlayerFactory>)playerFactory {
+                     playerFactory:(id<FVPPlayerFactory>)playerFactory 
+                      isLiveStream:(BOOL)isLiveStream {
   self = [super init];
   NSAssert(self, @"super init cannot be nil");
 
   _player = [AVPlayer playerWithPlayerItem:item];
   _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
+
+  _isLiveStream = isLiveStream;
 
   // This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
   // (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some
@@ -323,6 +330,7 @@ NS_INLINE UIViewController *rootViewController(void) {
         [[AVPictureInPictureController alloc] initWithPlayerLayer:self.playerLayer];
     [self setAutomaticallyStartsPictureInPicture:NO];
     self.pictureInPictureController.delegate = self;
+    self.pictureInPictureController.requiresLinearPlayback = _isLiveStream;
   }
 }
 
@@ -672,6 +680,10 @@ NS_INLINE UIViewController *rootViewController(void) {
 
 @implementation FLTVideoPlayerPlugin
 bool _remoteCommandsInitialized;
+NSString *_title;
+NSString *_artist;
+NSString *_imageUrl;
+NSNumber *_isLiveStream;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FLTVideoPlayerPlugin *instance = [[FLTVideoPlayerPlugin alloc] initWithRegistrar:registrar];
@@ -733,6 +745,12 @@ bool _remoteCommandsInitialized;
 
 - (FLTTextureMessage *)create:(FLTCreateMessage *)input error:(FlutterError **)error {
   FLTFrameUpdater *frameUpdater = [[FLTFrameUpdater alloc] initWithRegistry:_registry];
+
+  _title = input.title;
+  _artist = input.artist;
+  _imageUrl = input.imageUrl;
+  _isLiveStream = input.isLiveStream;
+
   FLTVideoPlayer *player;
   if (input.asset) {
     NSString *assetPath;
@@ -749,7 +767,9 @@ bool _remoteCommandsInitialized;
     player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:input.uri]
                                     frameUpdater:frameUpdater
                                      httpHeaders:input.httpHeaders
-                                   playerFactory:_playerFactory];
+                                   playerFactory:_playerFactory
+                                    isLiveStream:[_isLiveStream boolValue]];
+
     return [self onPlayerSetup:player frameUpdater:frameUpdater];
   } else {
     *error = [FlutterError errorWithCode:@"video_player" message:@"not implemented" details:nil];
@@ -893,13 +913,15 @@ bool _remoteCommandsInitialized;
     return MPRemoteCommandHandlerStatusSuccess;
   }];
 
-  // [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = @{
-  //   MPMediaItemPropertyTitle: @"番組名",
-  //   MPMediaItemPropertyArtist: @"チャンネル名",
-  //   MPMediaItemPropertyPlaybackDuration: @(player.duration),
-  //   MPNowPlayingInfoPropertyElapsedPlaybackTime: @(player.position),
-  //   MPNowPlayingInfoPropertyPlaybackRate: @(player.isPlaying ? 1.0 : 0.0),
-  // };
+  [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = @{
+    MPMediaItemPropertyTitle: _title,
+    MPMediaItemPropertyArtist: _artist,
+    MPMediaItemPropertyPlaybackDuration: @(player.duration / 1000),
+    MPNowPlayingInfoPropertyElapsedPlaybackTime: @(player.position / 1000),
+    MPNowPlayingInfoPropertyIsLiveStream: _isLiveStream,
+  };
+
+  // TODO: サムネを設定する
 
   _remoteCommandsInitialized = true;
 }

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
@@ -78,12 +78,20 @@ NS_ASSUME_NONNULL_BEGIN
     uri:(nullable NSString *)uri
     packageName:(nullable NSString *)packageName
     formatHint:(nullable NSString *)formatHint
-    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders;
+    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+    title:(NSString *)title
+    artist:(NSString *)artist
+    imageUrl:(nullable NSString *)imageUrl
+    isLiveStream:(NSNumber *)isLiveStream;
 @property(nonatomic, copy, nullable) NSString * asset;
 @property(nonatomic, copy, nullable) NSString * uri;
 @property(nonatomic, copy, nullable) NSString * packageName;
 @property(nonatomic, copy, nullable) NSString * formatHint;
 @property(nonatomic, strong) NSDictionary<NSString *, NSString *> * httpHeaders;
+@property(nonatomic, copy) NSString * title;
+@property(nonatomic, copy) NSString * artist;
+@property(nonatomic, copy, nullable) NSString * imageUrl;
+@property(nonatomic, strong) NSNumber * isLiveStream;
 @end
 
 @interface FLTMixWithOthersMessage : NSObject

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
@@ -248,13 +248,21 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     uri:(nullable NSString *)uri
     packageName:(nullable NSString *)packageName
     formatHint:(nullable NSString *)formatHint
-    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders {
+    httpHeaders:(NSDictionary<NSString *, NSString *> *)httpHeaders
+    title:(NSString *)title
+    artist:(NSString *)artist
+    imageUrl:(nullable NSString *)imageUrl
+    isLiveStream:(NSNumber *)isLiveStream {
   FLTCreateMessage* pigeonResult = [[FLTCreateMessage alloc] init];
   pigeonResult.asset = asset;
   pigeonResult.uri = uri;
   pigeonResult.packageName = packageName;
   pigeonResult.formatHint = formatHint;
   pigeonResult.httpHeaders = httpHeaders;
+  pigeonResult.title = title;
+  pigeonResult.artist = artist;
+  pigeonResult.imageUrl = imageUrl;
+  pigeonResult.isLiveStream = isLiveStream;
   return pigeonResult;
 }
 + (FLTCreateMessage *)fromList:(NSArray *)list {
@@ -265,6 +273,13 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.formatHint = GetNullableObjectAtIndex(list, 3);
   pigeonResult.httpHeaders = GetNullableObjectAtIndex(list, 4);
   NSAssert(pigeonResult.httpHeaders != nil, @"");
+  pigeonResult.title = GetNullableObjectAtIndex(list, 5);
+  NSAssert(pigeonResult.title != nil, @"");
+  pigeonResult.artist = GetNullableObjectAtIndex(list, 6);
+  NSAssert(pigeonResult.artist != nil, @"");
+  pigeonResult.imageUrl = GetNullableObjectAtIndex(list, 7);
+  pigeonResult.isLiveStream = GetNullableObjectAtIndex(list, 8);
+  NSAssert(pigeonResult.isLiveStream != nil, @"");
   return pigeonResult;
 }
 + (nullable FLTCreateMessage *)nullableFromList:(NSArray *)list {
@@ -277,6 +292,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     (self.packageName ?: [NSNull null]),
     (self.formatHint ?: [NSNull null]),
     (self.httpHeaders ?: [NSNull null]),
+    (self.title ?: [NSNull null]),
+    (self.artist ?: [NSNull null]),
+    (self.imageUrl ?: [NSNull null]),
+    (self.isLiveStream ?: [NSNull null]),
   ];
 }
 @end

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -89,6 +89,10 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
       uri: uri,
       httpHeaders: httpHeaders,
       formatHint: formatHint,
+      title: dataSource.mediaInfo?.title ?? '',
+      artist: dataSource.mediaInfo?.artist ?? '',
+      imageUrl: dataSource.mediaInfo?.imageUrl,
+      isLiveStream: dataSource.isLiveStream,
     );
 
     final TextureMessage response = await _api.create(message);

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -180,6 +180,10 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
             eventType: VideoEventType.isPlayingStateUpdate,
             isPlaying: map['isPlaying'] as bool,
           );
+        case 'play':
+          return VideoEvent(eventType: VideoEventType.play);
+        case 'pause':
+          return VideoEvent(eventType: VideoEventType.pause);
         default:
           return VideoEvent(eventType: VideoEventType.unknown);
       }

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -143,6 +143,10 @@ class CreateMessage {
     this.packageName,
     this.formatHint,
     required this.httpHeaders,
+    required this.title,
+    required this.artist,
+    this.imageUrl,
+    required this.isLiveStream,
   });
 
   String? asset;
@@ -155,6 +159,14 @@ class CreateMessage {
 
   Map<String?, String?> httpHeaders;
 
+  String title;
+
+  String artist;
+
+  String? imageUrl;
+
+  bool isLiveStream;
+
   Object encode() {
     return <Object?>[
       asset,
@@ -162,6 +174,10 @@ class CreateMessage {
       packageName,
       formatHint,
       httpHeaders,
+      title,
+      artist,
+      imageUrl,
+      isLiveStream,
     ];
   }
 
@@ -173,6 +189,10 @@ class CreateMessage {
       packageName: result[2] as String?,
       formatHint: result[3] as String?,
       httpHeaders: (result[4] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+      title: result[5]! as String,
+      artist: result[6]! as String,
+      imageUrl: result[7] as String?,
+      isLiveStream: result[8]! as bool,
     );
   }
 }

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -49,13 +49,17 @@ class PositionMessage {
 }
 
 class CreateMessage {
-  CreateMessage({required this.httpHeaders});
+  CreateMessage({required this.httpHeaders, this.title = '', this.artist = '', this.isLiveStream = false});
 
   String? asset;
   String? uri;
   String? packageName;
   String? formatHint;
   Map<String?, String?> httpHeaders;
+  String title;
+  String artist;
+  String? imageUrl;
+  bool isLiveStream;
 }
 
 class MixWithOthersMessage {

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -170,6 +170,8 @@ class DataSource {
     this.asset,
     this.package,
     this.httpHeaders = const <String, String>{},
+    this.mediaInfo,
+    this.isLiveStream = false,
   });
 
   /// The way in which the video was originally loaded.
@@ -199,6 +201,11 @@ class DataSource {
   /// The package that the asset was loaded from. Only set for
   /// [DataSourceType.asset] videos.
   final String? package;
+
+  /// iOSではコントロールセンター、AndroidではNotificationに表示されるメディア情報
+  final MediaInfo? mediaInfo;
+
+  final bool isLiveStream;
 }
 
 /// The way in which the video was originally loaded.
@@ -495,4 +502,17 @@ enum MuxVideoStreamType {
 enum MuxPageType {
   watchpage,
   iframe,
+}
+
+@immutable
+class MediaInfo {
+  const MediaInfo({
+    required this.title,
+    required this.artist,
+    this.imageUrl,
+  });
+
+  final String title;
+  final String artist;
+  final String? imageUrl;
 }

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -340,6 +340,14 @@ enum VideoEventType {
   /// phone calls, or other app media such as music players.
   isPlayingStateUpdate,
 
+  /// The video is set to play
+  /// for iOS event
+  play,
+
+  /// The video is set to pause
+  /// for iOS event
+  pause,
+
   /// An unknown event has been received.
   unknown,
 }


### PR DESCRIPTION
- iOSのRemoteControlやPipから再生・一時停止操作をしたとき、VideoPlayerの保持している状態と、動画プレイヤーの状態がずれてしまっていた
  - 「Pip上では停止しているように見えるがプレイヤー自体は動いているのでロック画面やアプリを開くと勝手に再生される」現象が起きていた
  - RemoteControlから一時停止した状態でPipから再生しようとすると、内部的には一時停止しようとしてしまうため、Pipから再生できなくなってしまっていた
- 上記の問題を修正する過程で、RemoteControlとの接続を永続化するためにメディア情報を渡す必要があったため、メディア情報を渡すAPIを実装した
  - Flutterとの通信部分ではサムネURLを渡せるようにしたが、サムネを表示する機能は未実装
  - iOSのみ対応で、Androidは未実装