### PR TITLE
Feature: Androidでメディアコントロールを表示する

### DIFF
--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -58,6 +58,8 @@ android {
         implementation "com.google.android.exoplayer:exoplayer-hls:${exoplayer_version}"
         implementation "com.google.android.exoplayer:exoplayer-dash:${exoplayer_version}"
         implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:${exoplayer_version}"
+        implementation "com.google.android.exoplayer:exoplayer-ui:${exoplayer_version}"
+        implementation "com.google.android.exoplayer:extension-mediasession:${exoplayer_version}"
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'androidx.test:core:1.3.0'
         testImplementation 'org.mockito:mockito-inline:5.0.0'

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -54,12 +54,14 @@ android {
 
     dependencies {
         def exoplayer_version = "2.18.7"
+        def picasso_version = "2.8"
         implementation "com.google.android.exoplayer:exoplayer-core:${exoplayer_version}"
         implementation "com.google.android.exoplayer:exoplayer-hls:${exoplayer_version}"
         implementation "com.google.android.exoplayer:exoplayer-dash:${exoplayer_version}"
         implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:${exoplayer_version}"
         implementation "com.google.android.exoplayer:exoplayer-ui:${exoplayer_version}"
         implementation "com.google.android.exoplayer:extension-mediasession:${exoplayer_version}"
+        implementation "com.squareup.picasso:picasso:${picasso_version}"
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'androidx.test:core:1.3.0'
         testImplementation 'org.mockito:mockito-inline:5.0.0'

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -456,6 +456,65 @@ public class Messages {
       this.httpHeaders = setterArg;
     }
 
+    private @NonNull String title;
+
+    public @NonNull String getTitle() {
+      return title;
+    }
+
+    public void setTitle(@NonNull String setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"title\" is null.");
+      }
+      this.title = setterArg;
+    }
+
+    private @NonNull String artist;
+
+    public @NonNull String getArtist() {
+      return artist;
+    }
+
+    public void setArtist(@NonNull String setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"artist\" is null.");
+      }
+      this.artist = setterArg;
+    }
+
+    private @Nullable String artworkUrl;
+
+    public @Nullable String getArtworkUrl() {
+      return artworkUrl;
+    }
+
+    public void setArtworkUrl(@Nullable String setterArg) {
+      this.artworkUrl = setterArg;
+    }
+
+    private @Nullable String defaultArtworkAssetPath;
+
+    public @Nullable String getDefaultArtworkAssetPath() {
+      return defaultArtworkAssetPath;
+    }
+
+    public void setDefaultArtworkAssetPath(@Nullable String setterArg) {
+      this.defaultArtworkAssetPath = setterArg;
+    }
+
+    private @NonNull Boolean isLiveStream;
+
+    public @NonNull Boolean getIsLiveStream() {
+      return isLiveStream;
+    }
+
+    public void setIsLiveStream(@NonNull Boolean setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"isLiveStream\" is null.");
+      }
+      this.isLiveStream = setterArg;
+    }
+
     /** Constructor is non-public to enforce null safety; use Builder. */
     CreateMessage() {}
 
@@ -496,6 +555,41 @@ public class Messages {
         return this;
       }
 
+      private @Nullable String title;
+
+      public @NonNull Builder setTitle(@NonNull String setterArg) {
+        this.title = setterArg;
+        return this;
+      }
+
+      private @Nullable String artist;
+
+      public @NonNull Builder setArtist(@NonNull String setterArg) {
+        this.artist = setterArg;
+        return this;
+      }
+
+      private @Nullable String artworkUrl;
+
+      public @NonNull Builder setArtworkUrl(@Nullable String setterArg) {
+        this.artworkUrl = setterArg;
+        return this;
+      }
+
+      private @Nullable String defaultArtworkAssetPath;
+
+      public @NonNull Builder setDefaultArtworkAssetPath(@Nullable String setterArg) {
+        this.defaultArtworkAssetPath = setterArg;
+        return this;
+      }
+
+      private @Nullable Boolean isLiveStream;
+
+      public @NonNull Builder setIsLiveStream(@NonNull Boolean setterArg) {
+        this.isLiveStream = setterArg;
+        return this;
+      }
+
       public @NonNull CreateMessage build() {
         CreateMessage pigeonReturn = new CreateMessage();
         pigeonReturn.setAsset(asset);
@@ -503,18 +597,28 @@ public class Messages {
         pigeonReturn.setPackageName(packageName);
         pigeonReturn.setFormatHint(formatHint);
         pigeonReturn.setHttpHeaders(httpHeaders);
+        pigeonReturn.setTitle(title);
+        pigeonReturn.setArtist(artist);
+        pigeonReturn.setArtworkUrl(artworkUrl);
+        pigeonReturn.setDefaultArtworkAssetPath(defaultArtworkAssetPath);
+        pigeonReturn.setIsLiveStream(isLiveStream);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<Object>(5);
+      ArrayList<Object> toListResult = new ArrayList<Object>(10);
       toListResult.add(asset);
       toListResult.add(uri);
       toListResult.add(packageName);
       toListResult.add(formatHint);
       toListResult.add(httpHeaders);
+      toListResult.add(title);
+      toListResult.add(artist);
+      toListResult.add(artworkUrl);
+      toListResult.add(defaultArtworkAssetPath);
+      toListResult.add(isLiveStream);
       return toListResult;
     }
 
@@ -530,6 +634,16 @@ public class Messages {
       pigeonResult.setFormatHint((String) formatHint);
       Object httpHeaders = list.get(4);
       pigeonResult.setHttpHeaders((Map<String, String>) httpHeaders);
+      Object title = list.get(5);
+      pigeonResult.setTitle((String) title);
+      Object artist = list.get(6);
+      pigeonResult.setArtist((String) artist);
+      Object artworkUrl = list.get(7);
+      pigeonResult.setArtworkUrl((String) artworkUrl);
+      Object defaultArtworkAssetPath = list.get(8);
+      pigeonResult.setDefaultArtworkAssetPath((String) defaultArtworkAssetPath);
+      Object isLiveStream = list.get(9);
+      pigeonResult.setIsLiveStream((Boolean) isLiveStream);
       return pigeonResult;
     }
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -55,7 +55,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.io.FileDescriptor;
+import java.io.InputStream;
 
 final class VideoPlayer {
   private static final String FORMAT_SS = "ss";
@@ -329,7 +329,6 @@ final class VideoPlayer {
         artworkUrl, defaultArtworkAssetPath));
 
     playerNotificationManager.setMediaSessionToken(mediaSession.getSessionToken());
-    System.out.println("🐤🐤🐤");
 
     initialized = true;
   }
@@ -383,8 +382,19 @@ final class VideoPlayer {
       public MediaMetadataCompat getMetadata​(Player player) {
         MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder()
             .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, title)
-            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
-            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ART_URI, artworkUrl);
+            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist);
+
+        Bitmap bmp = null;
+        try {
+          InputStream stream = context.getAssets().open(defaultArtworkAssetPath);
+          bmp = BitmapFactory.decodeStream(stream);
+        } catch (Exception exception) {
+          System.out.println("🐤🐤🐤 " + exception);
+        }
+        System.out.println("🐤🐤🐤 < " + (bmp != null ? "👍" : "👎"));
+        if (bmp != null) {
+          builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, bmp);
+        }
 
         if (!isLiveStream) {
           builder
@@ -419,11 +429,10 @@ final class VideoPlayer {
 
       @Override
       public Bitmap getCurrentLargeIcon(Player player, PlayerNotificationManager.BitmapCallback callback) {
-
         if (defaultArtworkAssetPath != null) {
           try {
-            AssetFileDescriptor fd = context.getAssets().openFd(defaultArtworkAssetPath);
-            Bitmap bmp = BitmapFactory.decodeFileDescriptor(fd.getFileDescriptor());
+            InputStream stream = context.getAssets().open(defaultArtworkAssetPath);
+            return BitmapFactory.decodeStream(stream);
           } catch (Exception exception) {
             System.out.println("🐤🐤🐤 " + exception);
           }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -277,11 +277,17 @@ final class VideoPlayer {
         !isMixMode);
   }
 
-  void setupNotification(Context context) {
+  void setupNotification(Context context,
+      String title, String artist, Boolean isLiveStream,
+      String artworkUrl, String defaultArtworkAssetPath) {
     playerNotificationManager = new PlayerNotificationManager.Builder(context,
         NOTIFICATION_ID,
         NOTIFICATION_CHANNEL)
-        .setMediaDescriptionAdapter(createMediaDescriptionAdapter(context))
+        .setMediaDescriptionAdapter(
+            createMediaDescriptionAdapter(
+                context,
+                title, artist, isLiveStream,
+                artworkUrl, defaultArtworkAssetPath))
         .build();
 
     playerNotificationManager.setPlayer(exoPlayer);
@@ -290,18 +296,18 @@ final class VideoPlayer {
     playerNotificationManager.setUseStopAction(false);
   }
 
-  private MediaDescriptionAdapter createMediaDescriptionAdapter(Context context) {
+  private MediaDescriptionAdapter createMediaDescriptionAdapter(Context context,
+      String title, String artist, Boolean isLiveStream,
+      String artworkUrl, String defaultArtworkAssetPath) {
     return new MediaDescriptionAdapter() {
       @Override
       public String getCurrentContentTitle(Player player) {
-        return "番組名";
-        // return title;
+        return title;
       }
 
       @Override
       public String getCurrentContentText(Player player) {
-        return "チャンネル名";
-        // return author;
+        return artist;
       }
 
       @Override

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -10,7 +10,9 @@ import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.view.Surface;
 import androidx.annotation.NonNull;
@@ -45,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.io.FileDescriptor;
 
 final class VideoPlayer {
   private static final String FORMAT_SS = "ss";
@@ -321,6 +324,14 @@ final class VideoPlayer {
 
       @Override
       public Bitmap getCurrentLargeIcon(Player player, PlayerNotificationManager.BitmapCallback callback) {
+        if (defaultArtworkAssetPath != null) {
+          try {
+            AssetFileDescriptor fd = context.getAssets().openFd(defaultArtworkAssetPath);
+            Bitmap bmp = BitmapFactory.decodeFileDescriptor(fd.getFileDescriptor());
+          } catch (Exception exception) {
+            System.out.println("🐤🐤🐤 " + exception);
+          }
+        }
         return null;
 
         // OneTimeWorkRequest imageWorkRequest = new

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -153,7 +153,9 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     artist = arg.getArtist();
     isLiveStream = arg.getIsLiveStream();
     artworkUrl = arg.getArtworkUrl();
-    defaultArtworkAssetPath = arg.getDefaultArtworkAssetPath();
+    defaultArtworkAssetPath = arg.getDefaultArtworkAssetPath() != null
+        ? flutterState.keyForAsset.get(arg.getDefaultArtworkAssetPath())
+        : null;
 
     VideoPlayer player;
     if (arg.getAsset() != null) {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -45,22 +45,28 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   private String videoSource;
   private MuxStatsExoPlayer muxStatsExoPlayer;
 
-  /** Register this with the v2 embedding for the plugin to respond to lifecycle callbacks. */
-  public VideoPlayerPlugin() {}
+  /**
+   * Register this with the v2 embedding for the plugin to respond to lifecycle
+   * callbacks.
+   */
+  public VideoPlayerPlugin() {
+  }
 
   @SuppressWarnings("deprecation")
   private VideoPlayerPlugin(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    this.flutterState =
-        new FlutterState(
-            registrar.context(),
-            registrar.messenger(),
-            registrar::lookupKeyForAsset,
-            registrar::lookupKeyForAsset,
-            registrar.textures());
+    this.flutterState = new FlutterState(
+        registrar.context(),
+        registrar.messenger(),
+        registrar::lookupKeyForAsset,
+        registrar::lookupKeyForAsset,
+        registrar.textures());
     flutterState.startListening(this, registrar.messenger());
   }
 
-  /** Registers this with the stable v1 embedding. Will not respond to lifecycle events. */
+  /**
+   * Registers this with the stable v1 embedding. Will not respond to lifecycle
+   * events.
+   */
   @SuppressWarnings("deprecation")
   public static void registerWith(
       @NonNull io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
@@ -88,13 +94,12 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     }
 
     final FlutterInjector injector = FlutterInjector.instance();
-    this.flutterState =
-        new FlutterState(
-            binding.getApplicationContext(),
-            binding.getBinaryMessenger(),
-            injector.flutterLoader()::getLookupKeyForAsset,
-            injector.flutterLoader()::getLookupKeyForAsset,
-            binding.getTextureRegistry());
+    this.flutterState = new FlutterState(
+        binding.getApplicationContext(),
+        binding.getBinaryMessenger(),
+        injector.flutterLoader()::getLookupKeyForAsset,
+        injector.flutterLoader()::getLookupKeyForAsset,
+        binding.getTextureRegistry());
     flutterState.startListening(this, binding.getBinaryMessenger());
   }
 
@@ -121,7 +126,8 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     }
 
     // instances
-    // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved this may
+    // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is
+    // resolved this may
     // be replaced with just asserting that videoPlayers.isEmpty().
     // https://github.com/flutter/flutter/issues/20989 tracks this.
     disposeAllPlayers();
@@ -132,41 +138,36 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   }
 
   public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
-    TextureRegistry.SurfaceTextureEntry handle =
-        flutterState.textureRegistry.createSurfaceTexture();
-    EventChannel eventChannel =
-        new EventChannel(
-            flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
+    TextureRegistry.SurfaceTextureEntry handle = flutterState.textureRegistry.createSurfaceTexture();
+    EventChannel eventChannel = new EventChannel(
+        flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
 
     VideoPlayer player;
     if (arg.getAsset() != null) {
       String assetLookupKey;
       if (arg.getPackageName() != null) {
-        assetLookupKey =
-            flutterState.keyForAssetAndPackageName.get(arg.getAsset(), arg.getPackageName());
+        assetLookupKey = flutterState.keyForAssetAndPackageName.get(arg.getAsset(), arg.getPackageName());
       } else {
         assetLookupKey = flutterState.keyForAsset.get(arg.getAsset());
       }
-      player =
-          new VideoPlayer(
-              flutterState.applicationContext,
-              eventChannel,
-              handle,
-              "asset:///" + assetLookupKey,
-              null,
-              new HashMap<>(),
-              options);
+      player = new VideoPlayer(
+          flutterState.applicationContext,
+          eventChannel,
+          handle,
+          "asset:///" + assetLookupKey,
+          null,
+          new HashMap<>(),
+          options);
     } else {
       Map<String, String> httpHeaders = arg.getHttpHeaders();
-      player =
-          new VideoPlayer(
-              flutterState.applicationContext,
-              eventChannel,
-              handle,
-              arg.getUri(),
-              arg.getFormatHint(),
-              httpHeaders,
-              options);
+      player = new VideoPlayer(
+          flutterState.applicationContext,
+          eventChannel,
+          handle,
+          arg.getUri(),
+          arg.getFormatHint(),
+          httpHeaders,
+          options);
     }
     videoPlayers.put(handle.id(), player);
 
@@ -271,16 +272,16 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
 
   public void play(@NonNull TextureMessage arg) {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
+    player.setupNotification(flutterState.applicationContext);
     player.play();
   }
 
   public @NonNull PositionMessage position(@NonNull TextureMessage arg) {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    PositionMessage result =
-        new PositionMessage.Builder()
-            .setPosition(player.getPosition())
-            .setTextureId(arg.getTextureId())
-            .build();
+    PositionMessage result = new PositionMessage.Builder()
+        .setPosition(player.getPosition())
+        .setTextureId(arg.getTextureId())
+        .build();
     player.sendBufferingUpdate();
     return result;
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.os.Build;
 import android.util.LongSparseArray;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.mux.stats.sdk.core.model.CustomData;
 import com.mux.stats.sdk.core.model.CustomerData;
@@ -44,6 +45,12 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   private final VideoPlayerOptions options = new VideoPlayerOptions();
   private String videoSource;
   private MuxStatsExoPlayer muxStatsExoPlayer;
+
+  private @NonNull String title = "";
+  private @NonNull String artist = "";
+  private @NonNull Boolean isLiveStream = false;
+  private @Nullable String artworkUrl;
+  private @Nullable String defaultArtworkAssetPath;
 
   /**
    * Register this with the v2 embedding for the plugin to respond to lifecycle
@@ -141,6 +148,12 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     TextureRegistry.SurfaceTextureEntry handle = flutterState.textureRegistry.createSurfaceTexture();
     EventChannel eventChannel = new EventChannel(
         flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
+
+    title = arg.getTitle();
+    artist = arg.getArtist();
+    isLiveStream = arg.getIsLiveStream();
+    artworkUrl = arg.getArtworkUrl();
+    defaultArtworkAssetPath = arg.getDefaultArtworkAssetPath();
 
     VideoPlayer player;
     if (arg.getAsset() != null) {
@@ -272,7 +285,9 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
 
   public void play(@NonNull TextureMessage arg) {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
-    player.setupNotification(flutterState.applicationContext);
+    player.setupNotification(flutterState.applicationContext,
+        title, artist, isLiveStream,
+        artworkUrl, defaultArtworkAssetPath);
     player.play();
   }
 

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -61,6 +61,11 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
       uri: uri,
       httpHeaders: httpHeaders,
       formatHint: formatHint,
+      title: dataSource.mediaInfo?.title ?? '',
+      artist: dataSource.mediaInfo?.artist ?? '',
+      artworkUrl: dataSource.mediaInfo?.artworkUrl,
+      defaultArtworkAssetPath: dataSource.mediaInfo?.defaultArtworkAssetPath,
+      isLiveStream: dataSource.isLiveStream,
     );
 
     final TextureMessage response = await _api.create(message);

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -143,6 +143,11 @@ class CreateMessage {
     this.packageName,
     this.formatHint,
     required this.httpHeaders,
+    required this.title,
+    required this.artist,
+    this.artworkUrl,
+    this.defaultArtworkAssetPath,
+    required this.isLiveStream,
   });
 
   String? asset;
@@ -155,6 +160,16 @@ class CreateMessage {
 
   Map<String?, String?> httpHeaders;
 
+  String title;
+
+  String artist;
+
+  String? artworkUrl;
+
+  String? defaultArtworkAssetPath;
+
+  bool isLiveStream;
+
   Object encode() {
     return <Object?>[
       asset,
@@ -162,6 +177,11 @@ class CreateMessage {
       packageName,
       formatHint,
       httpHeaders,
+      title,
+      artist,
+      artworkUrl,
+      defaultArtworkAssetPath,
+      isLiveStream,
     ];
   }
 
@@ -173,6 +193,11 @@ class CreateMessage {
       packageName: result[2] as String?,
       formatHint: result[3] as String?,
       httpHeaders: (result[4] as Map<Object?, Object?>?)!.cast<String?, String?>(),
+      title: result[5]! as String,
+      artist: result[6]! as String,
+      artworkUrl: result[7] as String?,
+      defaultArtworkAssetPath: result[8] as String?,
+      isLiveStream: result[9]! as bool,
     );
   }
 }

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -43,12 +43,18 @@ class PositionMessage {
 }
 
 class CreateMessage {
-  CreateMessage({required this.httpHeaders});
+  CreateMessage({required this.httpHeaders, this.title = '', this.artist = '', this.isLiveStream = false});
+
   String? asset;
   String? uri;
   String? packageName;
   String? formatHint;
   Map<String?, String?> httpHeaders;
+  String title;
+  String artist;
+  String? artworkUrl;
+  String? defaultArtworkAssetPath;
+  bool isLiveStream;
 }
 
 class MixWithOthersMessage {


### PR DESCRIPTION
参考：https://developers.cyberagent.co.jp/blog/archives/31631/

アプリ外からのPlayer操作を行うための仕組みがMediaSessionで、ロック画面などにUIを表示する仕組みがNotification。

MediaSessionとExoPlayerの連携をMediaSessionConnectorが、MediaSessionとNotificationの連携をPlayerNotificationManager がうまくやってくれている。


||アーカイブ|生放送|
|:-|:-|:-|
|Pixel2 / Android 13|<img width="380" alt="スクリーンショット 2023-12-07 20 26 08" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/898ecb2c-99af-4a22-b6d0-7cecd1bc2ef8">|<img width="374" alt="スクリーンショット 2023-12-07 20 26 41" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/4f657209-24b8-4865-b899-a6ec8b218cf6">|
|Pixel6 / Android 11|<img width="383" alt="スクリーンショット 2023-12-07 20 28 56" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/292f5192-bc03-4825-a6ee-fec6aa9cdcb8">|<img width="380" alt="スクリーンショット 2023-12-07 20 29 21" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/6db772e5-da70-4f85-bc0b-412161ef45fe">|
|Pixel4 / Android 10|<img width="387" alt="スクリーンショット 2023-12-07 20 31 38" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/a76db4e8-dd5b-4d3b-86df-1516ab8e47d3">|<img width="387" alt="スクリーンショット 2023-12-07 20 32 15" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/45101e9c-1cd2-4efb-a8db-98cb4248ae35">|
