### PR TITLE
fix: 通知をタップした時にアプリに復帰する処理が動いていなかった

### DIFF
--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -392,8 +392,14 @@ final class VideoPlayer {
 
       @Override
       public PendingIntent createCurrentContentIntent(Player player) {
-        return PendingIntent.getActivity(context, 0, new Intent(Intent.ACTION_MEDIA_BUTTON),
-            PendingIntent.FLAG_IMMUTABLE);
+        String packageName = context.getPackageName();
+        Intent notificationIntent = new Intent();
+        notificationIntent.setClassName(packageName, packageName + ".MainActivity");
+        notificationIntent.setFlags(
+          Intent.FLAG_ACTIVITY_CLEAR_TOP
+          | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        return PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE);
       }
 
       private Bitmap _bmp;


### PR DESCRIPTION
通知をタップした時のイベントに登録すべきイベントが誤っていて、アプリへの復帰が実行されていなかった

Android 10
<img width="300" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/8e1fd4db-e51c-4870-8925-747c3cbcec72">

Android 13
<img width="300" src="https://github.com/glucoseinc/flutter-packages/assets/74706880/34dcdc79-3831-4589-ba59-9379693bbdc8">

