### PR TITLE
MUXに送信するパラメータを追加

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,44 @@
+## 2.5.0
+
+* Migrates ExoPlayer to Media3-ExoPlayer 1.3.1.
+
+## 2.4.17
+
+* Revert Impeller support.
+
+## 2.4.16
+
+* [Supports Impeller](https://docs.flutter.dev/release/breaking-changes/android-surface-plugins).
+
+## 2.4.15
+
+* Updates minimum supported SDK version to Flutter 3.22/Dart 3.4.
+* Removes support for apps using the v1 Android embedding.
+
+## 2.4.14
+
+* Calls `onDestroy` instead of `initialize` in onDetachedFromEngine.
+
+## 2.4.13
+
+* Updates minSdkVersion to 19.
+* Updates minimum supported SDK version to Flutter 3.16/Dart 3.2.
+
+## 2.4.12
+
+* Updates compileSdk version to 34.
+* Adds error handling for `BehindLiveWindowException`, which may occur upon live-video playback failure.
+
+## 2.4.11
+
+* Updates minimum supported SDK version to Flutter 3.10/Dart 3.0.
+* Fixes new lint warnings.
+
+## 2.4.10
+
+* Adds pub topics to package metadata.
+* Updates minimum supported SDK version to Flutter 3.7/Dart 2.19.
+
 ## 2.4.9
 
 * Bumps ExoPlayer version to 2.18.7.

--- a/packages/video_player/video_player_android/CONTRIBUTING.md
+++ b/packages/video_player/video_player_android/CONTRIBUTING.md
@@ -7,7 +7,7 @@ command in this directory:
 flutter pub upgrade
 flutter pub run pigeon --input pigeons/messages.dart
 # git commit your changes so that your working environment is clean
-(cd ../../../; ./script/tool_runner.sh format --clang-format=clang-format-7)
+dart run ../../../script/tool/bin/flutter_plugin_tools.dart format --current-package
 ```
 
 If you update pigeon itself and want to test the changes here,

--- a/packages/video_player/video_player_android/android/build.gradle
+++ b/packages/video_player/video_player_android/android/build.gradle
@@ -53,20 +53,21 @@ android {
     }
 
     dependencies {
-        def exoplayer_version = "2.18.7"
+        def media3_version = "1.4.1"
         def picasso_version = "2.8"
-        implementation "com.google.android.exoplayer:exoplayer-core:${exoplayer_version}"
-        implementation "com.google.android.exoplayer:exoplayer-hls:${exoplayer_version}"
-        implementation "com.google.android.exoplayer:exoplayer-dash:${exoplayer_version}"
-        implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:${exoplayer_version}"
-        implementation "com.google.android.exoplayer:exoplayer-ui:${exoplayer_version}"
-        implementation "com.google.android.exoplayer:extension-mediasession:${exoplayer_version}"
+        implementation "androidx.media3:media3-exoplayer:${media3_version}"
+        implementation "androidx.media3:media3-exoplayer-hls:${media3_version}"
+        implementation "androidx.media3:media3-exoplayer-dash:${media3_version}"
+        implementation "androidx.media3:media3-exoplayer-smoothstreaming:${media3_version}"
+        implementation "androidx.media3:media3-ui:${media3_version}"
+        implementation "androidx.media3:media3-session:${media3_version}"
         implementation "com.squareup.picasso:picasso:${picasso_version}"
+        implementation "androidx.media:media:1.7.0"
         testImplementation 'junit:junit:4.13.2'
         testImplementation 'androidx.test:core:1.3.0'
         testImplementation 'org.mockito:mockito-inline:5.0.0'
         testImplementation 'org.robolectric:robolectric:4.10.3'
-        api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_16_1:2.7.2'
+        api 'com.mux.stats.sdk.muxstats:data-media3-at_1_4:1.8.0'   
     }
 
     testOptions {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -1084,6 +1084,16 @@ public class Messages {
       this.videoCdn = setterArg;
     }
 
+    private @Nullable String viewerPlanStatus;
+
+    public @Nullable String getViewerPlanStatus() {
+      return viewerPlanStatus;
+    }
+
+    public void setViewerPlanStatus(@Nullable String setterArg) {
+      this.viewerPlanStatus = setterArg;
+    }
+
     public static final class Builder {
 
       private @Nullable Long textureId;
@@ -1233,6 +1243,13 @@ public class Messages {
         return this;
       }
 
+      private @Nullable String viewerPlanStatus;
+
+      public @NonNull Builder setViewerPlanStatus(@Nullable String setterArg) {
+        this.viewerPlanStatus = setterArg;
+        return this;
+      }
+
       public @NonNull MuxConfigMessage build() {
         MuxConfigMessage pigeonReturn = new MuxConfigMessage();
         pigeonReturn.setTextureId(textureId);
@@ -1256,6 +1273,7 @@ public class Messages {
         pigeonReturn.setVideoProducer(videoProducer);
         pigeonReturn.setVideoEncodingVariant(videoEncodingVariant);
         pigeonReturn.setVideoCdn(videoCdn);
+        pigeonReturn.setViewerPlanStatus(viewerPlanStatus);
         return pigeonReturn;
       }
     }
@@ -1284,6 +1302,7 @@ public class Messages {
       toListResult.add(videoProducer);
       toListResult.add(videoEncodingVariant);
       toListResult.add(videoCdn);
+      toListResult.add(viewerPlanStatus);
       return toListResult;
     }
 
@@ -1331,6 +1350,8 @@ public class Messages {
       pigeonResult.setVideoEncodingVariant((String) videoEncodingVariant);
       Object videoCdn = list.get(20);
       pigeonResult.setVideoCdn((String) videoCdn);
+      Object viewerPlanStatus = list.get(21);
+      pigeonResult.setViewerPlanStatus((String) viewerPlanStatus);
       return pigeonResult;
     }
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -54,8 +54,7 @@ public class Messages {
     } else {
       errorList.add(exception.toString());
       errorList.add(exception.getClass().getSimpleName());
-      errorList.add(
-        "Cause: " + exception.getCause() + ", Stacktrace: " + Log.getStackTraceString(exception));
+      errorList.add("Cause: " + exception.getCause() + ", Stacktrace: " + Log.getStackTraceString(exception));
     }
     return errorList;
   }
@@ -1710,7 +1709,7 @@ public class Messages {
                   api.replaceDataSource(msgArg);
                   wrapped.add(0, null);
                 }
- catch (Throwable exception) {
+                catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1734,7 +1733,7 @@ public class Messages {
                   api.setupMux(msgArg);
                   wrapped.add(0, null);
                 }
- catch (Throwable exception) {
+                catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -104,7 +104,10 @@ public class Messages {
     static @NonNull TextureMessage fromList(@NonNull ArrayList<Object> list) {
       TextureMessage pigeonResult = new TextureMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId(
+          (textureId == null)
+              ? null
+              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       return pigeonResult;
     }
   }
@@ -175,7 +178,10 @@ public class Messages {
     static @NonNull LoopingMessage fromList(@NonNull ArrayList<Object> list) {
       LoopingMessage pigeonResult = new LoopingMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId(
+          (textureId == null)
+              ? null
+              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object isLooping = list.get(1);
       pigeonResult.setIsLooping((Boolean) isLooping);
       return pigeonResult;
@@ -248,7 +254,10 @@ public class Messages {
     static @NonNull VolumeMessage fromList(@NonNull ArrayList<Object> list) {
       VolumeMessage pigeonResult = new VolumeMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId(
+          (textureId == null)
+              ? null
+              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object volume = list.get(1);
       pigeonResult.setVolume((Double) volume);
       return pigeonResult;
@@ -321,7 +330,10 @@ public class Messages {
     static @NonNull PlaybackSpeedMessage fromList(@NonNull ArrayList<Object> list) {
       PlaybackSpeedMessage pigeonResult = new PlaybackSpeedMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId(
+          (textureId == null)
+              ? null
+              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object speed = list.get(1);
       pigeonResult.setSpeed((Double) speed);
       return pigeonResult;
@@ -394,9 +406,15 @@ public class Messages {
     static @NonNull PositionMessage fromList(@NonNull ArrayList<Object> list) {
       PositionMessage pigeonResult = new PositionMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId(
+          (textureId == null)
+              ? null
+              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object position = list.get(1);
-      pigeonResult.setPosition((position == null) ? null : ((position instanceof Integer) ? (Integer) position : (Long) position));
+      pigeonResult.setPosition(
+          (position == null)
+              ? null
+              : ((position instanceof Integer) ? (Integer) position : (Long) position));
       return pigeonResult;
     }
   }
@@ -1418,8 +1436,12 @@ public class Messages {
     static @NonNull MessageCodec<Object> getCodec() {
       return AndroidVideoPlayerApiCodec.INSTANCE;
     }
-    /**Sets up an instance of `AndroidVideoPlayerApi` to handle messages through the `binaryMessenger`. */
-    static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable AndroidVideoPlayerApi api) {
+    /**
+     * Sets up an instance of `AndroidVideoPlayerApi` to handle messages through the
+     * `binaryMessenger`.
+     */
+    static void setup(
+        @NonNull BinaryMessenger binaryMessenger, @Nullable AndroidVideoPlayerApi api) {
       {
         BasicMessageChannel<Object> channel =
             new BasicMessageChannel<>(
@@ -1431,8 +1453,7 @@ public class Messages {
                 try {
                   api.initialize();
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1455,8 +1476,7 @@ public class Messages {
                 try {
                   TextureMessage output = api.create(msgArg);
                   wrapped.add(0, output);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1479,8 +1499,7 @@ public class Messages {
                 try {
                   api.dispose(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1503,8 +1522,7 @@ public class Messages {
                 try {
                   api.setLooping(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1527,8 +1545,7 @@ public class Messages {
                 try {
                   api.setVolume(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1551,8 +1568,7 @@ public class Messages {
                 try {
                   api.setPlaybackSpeed(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1575,8 +1591,7 @@ public class Messages {
                 try {
                   api.play(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1599,8 +1614,7 @@ public class Messages {
                 try {
                   PositionMessage output = api.position(msgArg);
                   wrapped.add(0, output);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1623,8 +1637,7 @@ public class Messages {
                 try {
                   api.seekTo(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1647,8 +1660,7 @@ public class Messages {
                 try {
                   api.pause(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }
@@ -1671,8 +1683,7 @@ public class Messages {
                 try {
                   api.setMixWithOthers(msgArg);
                   wrapped.add(0, null);
-                }
- catch (Throwable exception) {
+                } catch (Throwable exception) {
                   ArrayList<Object> wrappedError = wrapError(exception);
                   wrapped = wrappedError;
                 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -104,10 +104,7 @@ public class Messages {
     static @NonNull TextureMessage fromList(@NonNull ArrayList<Object> list) {
       TextureMessage pigeonResult = new TextureMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId(
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       return pigeonResult;
     }
   }
@@ -178,10 +175,7 @@ public class Messages {
     static @NonNull LoopingMessage fromList(@NonNull ArrayList<Object> list) {
       LoopingMessage pigeonResult = new LoopingMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId(
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object isLooping = list.get(1);
       pigeonResult.setIsLooping((Boolean) isLooping);
       return pigeonResult;
@@ -254,10 +248,7 @@ public class Messages {
     static @NonNull VolumeMessage fromList(@NonNull ArrayList<Object> list) {
       VolumeMessage pigeonResult = new VolumeMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId(
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object volume = list.get(1);
       pigeonResult.setVolume((Double) volume);
       return pigeonResult;
@@ -330,10 +321,7 @@ public class Messages {
     static @NonNull PlaybackSpeedMessage fromList(@NonNull ArrayList<Object> list) {
       PlaybackSpeedMessage pigeonResult = new PlaybackSpeedMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId(
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object speed = list.get(1);
       pigeonResult.setSpeed((Double) speed);
       return pigeonResult;
@@ -406,15 +394,9 @@ public class Messages {
     static @NonNull PositionMessage fromList(@NonNull ArrayList<Object> list) {
       PositionMessage pigeonResult = new PositionMessage();
       Object textureId = list.get(0);
-      pigeonResult.setTextureId(
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
+      pigeonResult.setTextureId((textureId == null) ? null : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId));
       Object position = list.get(1);
-      pigeonResult.setPosition(
-          (position == null)
-              ? null
-              : ((position instanceof Integer) ? (Integer) position : (Long) position));
+      pigeonResult.setPosition((position == null) ? null : ((position instanceof Integer) ? (Integer) position : (Long) position));
       return pigeonResult;
     }
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -18,7 +18,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.Build;;
+import android.os.Build;
 import androidx.media3.session.MediaSession;
 import android.util.Log;
 import android.view.Surface;

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -4,52 +4,44 @@
 
 package io.flutter.plugins.videoplayer;
 
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
-import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
+import static androidx.media3.common.Player.REPEAT_MODE_ALL;
+import static androidx.media3.common.Player.REPEAT_MODE_OFF;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.Build;
-import android.support.v4.media.MediaMetadataCompat;
-import android.support.v4.media.session.MediaSessionCompat;
-import android.support.v4.media.session.PlaybackStateCompat;
+import android.os.Build;;
+import androidx.media3.session.MediaSession;
 import android.util.Log;
 import android.view.Surface;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.OptIn;
 import androidx.annotation.VisibleForTesting;
-import com.google.android.exoplayer2.C;
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.Format;
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.PlaybackException;
-import com.google.android.exoplayer2.PlaybackParameters;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.Player.Listener;
-import com.google.android.exoplayer2.audio.AudioAttributes;
-import com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector;
-import static com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector.MediaMetadataProvider;
-import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.ProgressiveMediaSource;
-import com.google.android.exoplayer2.source.dash.DashMediaSource;
-import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
-import com.google.android.exoplayer2.source.hls.HlsMediaSource;
-import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource;
-import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSource;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
-import com.google.android.exoplayer2.upstream.ResolvingDataSource;
-import com.google.android.exoplayer2.ui.PlayerNotificationManager;
-import static com.google.android.exoplayer2.ui.PlayerNotificationManager.MediaDescriptionAdapter;
-import com.google.android.exoplayer2.util.Util;
+import androidx.media3.common.AudioAttributes;
+import androidx.media3.common.C;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.MimeTypes;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.PlaybackParameters;
+import androidx.media3.common.Player;
+import androidx.media3.common.Player.Listener;
+import androidx.media3.common.VideoSize;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+import androidx.media3.ui.PlayerNotificationManager;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.view.TextureRegistry;
 import java.util.Arrays;
@@ -90,12 +82,11 @@ final class VideoPlayer {
 
   private final VideoPlayerOptions options;
 
-  private DefaultHttpDataSource.Factory httpDataSourceFactory = new DefaultHttpDataSource.Factory();
-  private ResolvingDataSource.Factory resolvingDataSourceFactory;
+  private final DefaultHttpDataSource.Factory httpDataSourceFactory;
 
   private String dataSource;
   private String formatHint;
-  private Map<String, String> httpHeaders = new HashMap<>();
+  private Map<String, String> httpHeaders;
 
   VideoPlayer(
       Context context,
@@ -112,19 +103,18 @@ final class VideoPlayer {
     this.options = options;
     this.httpHeaders = httpHeaders;
 
-    ExoPlayer exoPlayer = new ExoPlayer.Builder(context).build();
-    Uri uri = Uri.parse(dataSource);
+    MediaItem mediaItem =
+        new MediaItem.Builder()
+            .setUri(dataSource)
+            .setMimeType(mimeFromFormatHint(formatHint))
+            .build();
 
-    buildHttpDataSourceFactory(httpHeaders);
-    DataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context, httpDataSourceFactory);
+    httpDataSourceFactory = new DefaultHttpDataSource.Factory();
+    configureHttpDataSourceFactory(httpHeaders);
 
-    resolvingDataSourceFactory = new ResolvingDataSource.Factory(
-        dataSourceFactory,
-        dataSpec -> dataSpec.withRequestHeaders(httpHeaders));
+    ExoPlayer exoPlayer = buildExoPlayer(context, httpDataSourceFactory);
 
-    MediaSource mediaSource = buildMediaSource(uri, resolvingDataSourceFactory, formatHint);
-
-    exoPlayer.setMediaSource(mediaSource);
+    exoPlayer.setMediaItem(mediaItem);
     exoPlayer.prepare();
 
     setUpVideoPlayer(exoPlayer, new QueuingEventSink());
@@ -148,58 +138,14 @@ final class VideoPlayer {
   }
 
   @VisibleForTesting
-  public void buildHttpDataSourceFactory(@NonNull Map<String, String> httpHeaders) {
+  public void configureHttpDataSourceFactory(@NonNull Map<String, String> httpHeaders) {
     final boolean httpHeadersNotEmpty = !httpHeaders.isEmpty();
     final String userAgent = httpHeadersNotEmpty && httpHeaders.containsKey(USER_AGENT)
         ? httpHeaders.get(USER_AGENT)
         : "ExoPlayer";
 
-    httpDataSourceFactory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
-  }
-
-  private MediaSource buildMediaSource(
-      Uri uri, DataSource.Factory mediaDataSourceFactory, String formatHint) {
-    int type;
-    if (formatHint == null) {
-      type = Util.inferContentType(uri);
-    } else {
-      switch (formatHint) {
-        case FORMAT_SS:
-          type = C.CONTENT_TYPE_SS;
-          break;
-        case FORMAT_DASH:
-          type = C.CONTENT_TYPE_DASH;
-          break;
-        case FORMAT_HLS:
-          type = C.CONTENT_TYPE_HLS;
-          break;
-        case FORMAT_OTHER:
-          type = C.CONTENT_TYPE_OTHER;
-          break;
-        default:
-          type = -1;
-          break;
-      }
-    }
-    switch (type) {
-      case C.CONTENT_TYPE_SS:
-        return new SsMediaSource.Factory(
-            new DefaultSsChunkSource.Factory(mediaDataSourceFactory), mediaDataSourceFactory)
-            .createMediaSource(MediaItem.fromUri(uri));
-      case C.CONTENT_TYPE_DASH:
-        return new DashMediaSource.Factory(
-            new DefaultDashChunkSource.Factory(mediaDataSourceFactory), mediaDataSourceFactory)
-            .createMediaSource(MediaItem.fromUri(uri));
-      case C.CONTENT_TYPE_HLS:
-        return new HlsMediaSource.Factory(mediaDataSourceFactory)
-            .createMediaSource(MediaItem.fromUri(uri));
-      case C.CONTENT_TYPE_OTHER:
-        return new ProgressiveMediaSource.Factory(mediaDataSourceFactory)
-            .createMediaSource(MediaItem.fromUri(uri));
-      default: {
-        throw new IllegalStateException("Unsupported type: " + type);
-      }
-    }
+    unstableUpdateDataSourceFactory(
+        httpDataSourceFactory, httpHeaders, userAgent, httpHeadersNotEmpty);
   }
 
   private void setUpVideoPlayer(ExoPlayer exoPlayer, QueuingEventSink eventSink) {
@@ -260,7 +206,11 @@ final class VideoPlayer {
           @Override
           public void onPlayerError(@NonNull final PlaybackException error) {
             setBuffering(false);
-            if (eventSink != null) {
+            if (error.errorCode == PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW) {
+              // See https://exoplayer.dev/live-streaming.html#behindlivewindowexception-and-error_code_behind_live_window
+              exoPlayer.seekToDefaultPosition();
+              exoPlayer.prepare();
+            } else if (eventSink != null) {
               eventSink.error("VideoError", "Video player had error " + error, null);
             }
           }
@@ -299,6 +249,7 @@ final class VideoPlayer {
 
   private PlayerNotificationManager playerNotificationManager;
 
+  @SuppressWarnings("deprecation")
   void setupNotification(Context context,
       String title, String artist, Boolean isLiveStream,
       String artworkUrl, String defaultArtworkAssetPath) {
@@ -327,7 +278,7 @@ final class VideoPlayer {
 
     setupMediaSession(context);
 
-    playerNotificationManager.setMediaSessionToken(mediaSession.getSessionToken());
+    playerNotificationManager.setMediaSessionToken(mediaSession.getSessionCompatToken());
 
     initialized = true;
   }
@@ -342,33 +293,42 @@ final class VideoPlayer {
     notificationManager.createNotificationChannel(channel);
   }
 
-  private MediaSessionCompat mediaSession;
+  private MediaSession mediaSession;
 
-  private MediaSessionCompat setupMediaSession(Context context) {
+  private MediaSession setupMediaSession(Context context) {
     if (this.mediaSession != null)
       this.mediaSession.release();
 
-    PendingIntent pendingIntent = PendingIntent.getBroadcast(
-        context,
-        0,
-        new Intent(Intent.ACTION_MEDIA_BUTTON),
-        PendingIntent.FLAG_IMMUTABLE);
+    PendingIntent sessionActivity = buildSessionActivityPendingIntent(context);
 
-    MediaSessionCompat mediaSession = new MediaSessionCompat(context,
-        "VideoPlayer",
-        null,
-        pendingIntent);
+    MediaSession.Builder builder = new MediaSession.Builder(context, exoPlayer).setId("VideoPlayer");
+    if(sessionActivity != null){
+      builder.setSessionActivity(sessionActivity);
+    }
 
-    mediaSession.setActive(true);
-    MediaSessionConnector mediaSessionConnector = new MediaSessionConnector(mediaSession);
-    mediaSessionConnector.setEnabledPlaybackActions(
-        PlaybackStateCompat.ACTION_PLAY_PAUSE
-            | PlaybackStateCompat.ACTION_PLAY
-            | PlaybackStateCompat.ACTION_PAUSE);
-    mediaSessionConnector.setPlayer(exoPlayer);
+    this.mediaSession = builder.build();
+    return this.mediaSession;
+  }
 
-    this.mediaSession = mediaSession;
-    return mediaSession;
+  private PendingIntent buildSessionActivityPendingIntent(android.content.Context context) {
+    PackageManager pm = context.getPackageManager();
+    Intent launch = pm.getLaunchIntentForPackage(context.getPackageName());
+    if (launch == null) {
+      return null;
+    }
+
+    launch.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+    int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      flags |= PendingIntent.FLAG_IMMUTABLE;
+    }
+
+    try {
+      return PendingIntent.getActivity(context, 0, launch, flags);
+    } catch (Throwable t) {
+      return null;
+    }
   }
 
   // Picassoは渡されたTargetを弱参照で扱うので、保持しておかないとGCされてしまうことがある
@@ -376,10 +336,10 @@ final class VideoPlayer {
 
   // Android 11以降はMediaSessionにMediaMetadataを設定する方法もあるが、
   // Android 10には反映されないのと、動的にArtworkを差し替えるのが難しいので、MediaDescriptionAdapterを使う
-  private MediaDescriptionAdapter createMediaDescriptionAdapter(Context context,
+  private PlayerNotificationManager.MediaDescriptionAdapter createMediaDescriptionAdapter(Context context,
       String title, String artist, Boolean isLiveStream,
       String artworkUrl, String defaultArtworkAssetPath) {
-    return new MediaDescriptionAdapter() {
+    return new PlayerNotificationManager.MediaDescriptionAdapter() {
       @Override
       public String getCurrentContentTitle(Player player) {
         return title;
@@ -491,10 +451,14 @@ final class VideoPlayer {
       return;
 
     dataSource = newDataSource;
-    MediaSource mediaSource = buildMediaSource(Uri.parse(newDataSource), resolvingDataSourceFactory, formatHint);
+    // MediaSource mediaSource = buildMediaSource(Uri.parse(newDataSource), resolvingDataSourceFactory, formatHint);
+    MediaItem item = new MediaItem.Builder()
+      .setUri(newDataSource)
+      .setMimeType(mimeFromFormatHint(formatHint))
+      .build();
 
     exoPlayer.stop();
-    exoPlayer.setMediaSource(mediaSource);
+    exoPlayer.setMediaItem(item);
     exoPlayer.prepare();
   }
 
@@ -506,15 +470,15 @@ final class VideoPlayer {
       event.put("event", "initialized");
       event.put("duration", exoPlayer.getDuration());
 
-      if (exoPlayer.getVideoFormat() != null) {
-        Format videoFormat = exoPlayer.getVideoFormat();
-        int width = videoFormat.width;
-        int height = videoFormat.height;
-        int rotationDegrees = videoFormat.rotationDegrees;
+      VideoSize videoSize = exoPlayer.getVideoSize();
+      int width = videoSize.width;
+      int height = videoSize.height;
+      if (width != 0 && height != 0) {
+        int rotationDegrees = videoSize.unappliedRotationDegrees;
         // Switch the width/height if video was taken in portrait mode
         if (rotationDegrees == 90 || rotationDegrees == 270) {
-          width = exoPlayer.getVideoFormat().height;
-          height = exoPlayer.getVideoFormat().width;
+          width = videoSize.height;
+          height = videoSize.width;
         }
         event.put("width", width);
         event.put("height", height);
@@ -554,6 +518,48 @@ final class VideoPlayer {
     }
     if (exoPlayer != null) {
       exoPlayer.release();
+    }
+  }
+
+  @NonNull
+  private static ExoPlayer buildExoPlayer(
+      Context context, DataSource.Factory baseDataSourceFactory) {
+    DataSource.Factory dataSourceFactory =
+        new DefaultDataSource.Factory(context, baseDataSourceFactory);
+    DefaultMediaSourceFactory mediaSourceFactory =
+        new DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory);
+    return new ExoPlayer.Builder(context).setMediaSourceFactory(mediaSourceFactory).build();
+  }
+
+  @Nullable
+  private static String mimeFromFormatHint(@Nullable String formatHint) {
+    if (formatHint == null) {
+      return null;
+    }
+    switch (formatHint) {
+      case FORMAT_SS:
+        return MimeTypes.APPLICATION_SS;
+      case FORMAT_DASH:
+        return MimeTypes.APPLICATION_MPD;
+      case FORMAT_HLS:
+        return MimeTypes.APPLICATION_M3U8;
+      case FORMAT_OTHER:
+      default:
+        return null;
+    }
+  }
+
+  // TODO: migrate to stable API, see https://github.com/flutter/flutter/issues/147039
+  @OptIn(markerClass = UnstableApi.class)
+  private static void unstableUpdateDataSourceFactory(
+      DefaultHttpDataSource.Factory factory,
+      @NonNull Map<String, String> httpHeaders,
+      String userAgent,
+      boolean httpHeadersNotEmpty) {
+    factory.setUserAgent(userAgent).setAllowCrossProtocolRedirects(true);
+
+    if (httpHeadersNotEmpty) {
+      factory.setDefaultRequestProperties(httpHeaders);
     }
   }
 }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -10,11 +10,13 @@ import android.util.LongSparseArray;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import androidx.media3.exoplayer.ExoPlayer;
 import com.mux.stats.sdk.core.model.CustomData;
 import com.mux.stats.sdk.core.model.CustomerData;
 import com.mux.stats.sdk.core.model.CustomerPlayerData;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
-import com.mux.stats.sdk.muxstats.MuxStatsExoPlayer;
+import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3;
+import com.mux.stats.sdk.muxstats.ExoPlayerBinding;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -44,13 +46,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   private FlutterState flutterState;
   private final VideoPlayerOptions options = new VideoPlayerOptions();
   private String videoSource;
-  private MuxStatsExoPlayer muxStatsExoPlayer;
-
-  private @NonNull String title = "";
-  private @NonNull String artist = "";
-  private @NonNull Boolean isLiveStream = false;
-  private @Nullable String artworkUrl;
-  private @Nullable String defaultArtworkAssetPath;
+  private MuxStatsSdkMedia3<ExoPlayer> muxStats;
 
   /**
    * Register this with the v2 embedding for the plugin to respond to lifecycle
@@ -117,7 +113,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     }
     flutterState.stopListening(binding.getBinaryMessenger());
     flutterState = null;
-    initialize();
+    onDestroy();
   }
 
   private void disposeAllPlayers() {
@@ -128,8 +124,8 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   }
 
   private void onDestroy() {
-    if (muxStatsExoPlayer != null) {
-      muxStatsExoPlayer.release();
+    if (muxStats != null) {
+      muxStats.release();
     }
 
     // instances
@@ -144,16 +140,24 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     disposeAllPlayers();
   }
 
-  public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
-    TextureRegistry.SurfaceTextureEntry handle = flutterState.textureRegistry.createSurfaceTexture();
-    EventChannel eventChannel = new EventChannel(
-        flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
+  private String title;
+  private String artist;
+  private Boolean isLiveStream;
+  private String artworkUrl;
+  private String defaultArtworkAssetPath;
 
-    title = arg.getTitle();
-    artist = arg.getArtist();
-    isLiveStream = arg.getIsLiveStream();
-    artworkUrl = arg.getArtworkUrl();
-    defaultArtworkAssetPath = arg.getDefaultArtworkAssetPath() != null
+  public @NonNull TextureMessage create(@NonNull CreateMessage arg) {
+    TextureRegistry.SurfaceTextureEntry handle =
+        flutterState.textureRegistry.createSurfaceTexture();
+    EventChannel eventChannel =
+        new EventChannel(
+            flutterState.binaryMessenger, "flutter.io/videoPlayer/videoEvents" + handle.id());
+
+    String title = arg.getTitle();
+    String artist = arg.getArtist();
+    Boolean isLiveStream = arg.getIsLiveStream();
+    String artworkUrl = arg.getArtworkUrl();
+    String defaultArtworkAssetPath = arg.getDefaultArtworkAssetPath() != null
         ? flutterState.keyForAsset.get(arg.getDefaultArtworkAssetPath())
         : null;
 
@@ -165,14 +169,15 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
       } else {
         assetLookupKey = flutterState.keyForAsset.get(arg.getAsset());
       }
-      player = new VideoPlayer(
-          flutterState.applicationContext,
-          eventChannel,
-          handle,
-          "asset:///" + assetLookupKey,
-          null,
-          new HashMap<>(),
-          options);
+      player =
+          new VideoPlayer(
+              flutterState.applicationContext,
+              eventChannel,
+              handle,
+              "asset:///" + assetLookupKey,
+              null,
+              new HashMap<>(),
+              options);
     } else {
       Map<String, String> httpHeaders = arg.getHttpHeaders();
       player = new VideoPlayer(
@@ -249,9 +254,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     if (arg.getVideoEncodingVariant() != null)
       videoData.setVideoEncodingVariant(arg.getVideoEncodingVariant());
 
-    if (arg.getVideoCdn() != null)
-      videoData.setVideoCdn(arg.getVideoCdn());
-
     if (arg.getVideoDuration() != null) {
       videoData.setVideoDuration(castVideoDuration(arg.getVideoDuration()));
     }
@@ -260,8 +262,13 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     customerData.setCustomerPlayerData(playerData);
     customerData.setCustomData(customData);
 
-    muxStatsExoPlayer = new MuxStatsExoPlayer(flutterState.applicationContext, player.exoPlayer,
-        arg.getEnvKey(), customerData);
+    muxStats = new MuxStatsSdkMedia3<ExoPlayer>(
+      flutterState.applicationContext,
+      arg.getEnvKey(),
+      customerData,
+      player.exoPlayer,
+      new ExoPlayerBinding()
+    );
   }
 
   public void dispose(@NonNull TextureMessage arg) {

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -15,6 +15,7 @@ import com.mux.stats.sdk.core.model.CustomData;
 import com.mux.stats.sdk.core.model.CustomerData;
 import com.mux.stats.sdk.core.model.CustomerPlayerData;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
+import com.mux.stats.sdk.core.model.CustomerViewerData;
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3;
 import com.mux.stats.sdk.muxstats.ExoPlayerBinding;
 import io.flutter.FlutterInjector;
@@ -198,6 +199,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     VideoPlayer player = videoPlayers.get(arg.getTextureId());
     CustomerPlayerData playerData = new CustomerPlayerData();
     CustomerVideoData videoData = new CustomerVideoData();
+    CustomerViewerData viewerData = new CustomerViewerData();
     CustomData customData = new CustomData();
 
     CustomerData customerData = new CustomerData();
@@ -254,12 +256,22 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     if (arg.getVideoEncodingVariant() != null)
       videoData.setVideoEncodingVariant(arg.getVideoEncodingVariant());
 
+    // deprecatedになったが、iOS版との統一のために残しておく
+    // if (arg.getVideoCdn() != null)
+    //   videoData.setVideoCdn(arg.getVideoCdn());
+
     if (arg.getVideoDuration() != null) {
       videoData.setVideoDuration(castVideoDuration(arg.getVideoDuration()));
     }
 
+    System.out.println("viewer_plan_status: " + arg.getViewerPlanStatus());
+    if (arg.getViewerPlanStatus() != null) {
+      viewerData.setViewerPlanStatus(arg.getViewerPlanStatus());
+    }
+
     customerData.setCustomerVideoData(videoData);
     customerData.setCustomerPlayerData(playerData);
+    customerData.setCustomerViewerData(viewerData);
     customerData.setCustomData(customData);
 
     muxStats = new MuxStatsSdkMedia3<ExoPlayer>(

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -256,10 +256,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
     if (arg.getVideoEncodingVariant() != null)
       videoData.setVideoEncodingVariant(arg.getVideoEncodingVariant());
 
-    // deprecatedになったが、iOS版との統一のために残しておく
-    // if (arg.getVideoCdn() != null)
-    //   videoData.setVideoCdn(arg.getVideoCdn());
-
     if (arg.getVideoDuration() != null) {
       videoData.setVideoDuration(castVideoDuration(arg.getVideoDuration()));
     }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -264,7 +264,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
       videoData.setVideoDuration(castVideoDuration(arg.getVideoDuration()));
     }
 
-    System.out.println("viewer_plan_status: " + arg.getViewerPlanStatus());
     if (arg.getViewerPlanStatus() != null) {
       viewerData.setViewerPlanStatus(arg.getViewerPlanStatus());
     }

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerTest.java
@@ -5,22 +5,25 @@
 package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import com.google.android.exoplayer2.ExoPlayer;
-import com.google.android.exoplayer2.Format;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
+import android.graphics.SurfaceTexture;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.Player;
+import androidx.media3.common.VideoSize;
+import androidx.media3.datasource.DefaultHttpDataSource;
+import androidx.media3.exoplayer.ExoPlayer;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.view.TextureRegistry;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +39,7 @@ public class VideoPlayerTest {
   private ExoPlayer fakeExoPlayer;
   private EventChannel fakeEventChannel;
   private TextureRegistry.SurfaceTextureEntry fakeSurfaceTextureEntry;
+  private SurfaceTexture fakeSurfaceTexture;
   private VideoPlayerOptions fakeVideoPlayerOptions;
   private QueuingEventSink fakeEventSink;
   private DefaultHttpDataSource.Factory httpDataSourceFactorySpy;
@@ -49,6 +53,8 @@ public class VideoPlayerTest {
     fakeExoPlayer = mock(ExoPlayer.class);
     fakeEventChannel = mock(EventChannel.class);
     fakeSurfaceTextureEntry = mock(TextureRegistry.SurfaceTextureEntry.class);
+    fakeSurfaceTexture = mock(SurfaceTexture.class);
+    when(fakeSurfaceTextureEntry.surfaceTexture()).thenReturn(fakeSurfaceTexture);
     fakeVideoPlayerOptions = mock(VideoPlayerOptions.class);
     fakeEventSink = mock(QueuingEventSink.class);
     httpDataSourceFactorySpy = spy(new DefaultHttpDataSource.Factory());
@@ -65,7 +71,7 @@ public class VideoPlayerTest {
             fakeEventSink,
             httpDataSourceFactorySpy);
 
-    videoPlayer.buildHttpDataSourceFactory(new HashMap<>());
+    videoPlayer.configureHttpDataSourceFactory(new HashMap<>());
 
     verify(httpDataSourceFactorySpy).setUserAgent("ExoPlayer");
     verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
@@ -91,7 +97,7 @@ public class VideoPlayerTest {
           }
         };
 
-    videoPlayer.buildHttpDataSourceFactory(httpHeaders);
+    videoPlayer.configureHttpDataSourceFactory(httpHeaders);
 
     verify(httpDataSourceFactorySpy).setUserAgent("userAgent");
     verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
@@ -116,7 +122,7 @@ public class VideoPlayerTest {
           }
         };
 
-    videoPlayer.buildHttpDataSourceFactory(httpHeaders);
+    videoPlayer.configureHttpDataSourceFactory(httpHeaders);
 
     verify(httpDataSourceFactorySpy).setUserAgent("ExoPlayer");
     verify(httpDataSourceFactorySpy).setAllowCrossProtocolRedirects(true);
@@ -133,10 +139,9 @@ public class VideoPlayerTest {
             fakeVideoPlayerOptions,
             fakeEventSink,
             httpDataSourceFactorySpy);
-    Format testFormat =
-        new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(90).build();
+    VideoSize testVideoSize = new VideoSize(100, 200, 90, 1f);
 
-    when(fakeExoPlayer.getVideoFormat()).thenReturn(testFormat);
+    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
     when(fakeExoPlayer.getDuration()).thenReturn(10L);
 
     videoPlayer.isInitialized = true;
@@ -162,10 +167,9 @@ public class VideoPlayerTest {
             fakeVideoPlayerOptions,
             fakeEventSink,
             httpDataSourceFactorySpy);
-    Format testFormat =
-        new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(270).build();
+    VideoSize testVideoSize = new VideoSize(100, 200, 270, 1f);
 
-    when(fakeExoPlayer.getVideoFormat()).thenReturn(testFormat);
+    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
     when(fakeExoPlayer.getDuration()).thenReturn(10L);
 
     videoPlayer.isInitialized = true;
@@ -191,10 +195,9 @@ public class VideoPlayerTest {
             fakeVideoPlayerOptions,
             fakeEventSink,
             httpDataSourceFactorySpy);
-    Format testFormat =
-        new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(0).build();
+    VideoSize testVideoSize = new VideoSize(100, 200, 0, 1f);
 
-    when(fakeExoPlayer.getVideoFormat()).thenReturn(testFormat);
+    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
     when(fakeExoPlayer.getDuration()).thenReturn(10L);
 
     videoPlayer.isInitialized = true;
@@ -220,10 +223,9 @@ public class VideoPlayerTest {
             fakeVideoPlayerOptions,
             fakeEventSink,
             httpDataSourceFactorySpy);
-    Format testFormat =
-        new Format.Builder().setWidth(100).setHeight(200).setRotationDegrees(180).build();
+    VideoSize testVideoSize = new VideoSize(100, 200, 180, 1f);
 
-    when(fakeExoPlayer.getVideoFormat()).thenReturn(testFormat);
+    when(fakeExoPlayer.getVideoSize()).thenReturn(testVideoSize);
     when(fakeExoPlayer.getDuration()).thenReturn(10L);
 
     videoPlayer.isInitialized = true;
@@ -277,5 +279,29 @@ public class VideoPlayerTest {
 
     assertEquals(event2.get("event"), "isPlayingStateUpdate");
     assertEquals(event2.get("isPlaying"), false);
+  }
+
+  @Test
+  public void behindLiveWindowErrorResetsPlayerToDefaultPosition() {
+    List<Player.Listener> listeners = new LinkedList<>();
+    doAnswer(invocation -> listeners.add(invocation.getArgument(0)))
+        .when(fakeExoPlayer)
+        .addListener(any());
+
+    VideoPlayer unused =
+        new VideoPlayer(
+            fakeExoPlayer,
+            fakeEventChannel,
+            fakeSurfaceTextureEntry,
+            fakeVideoPlayerOptions,
+            fakeEventSink,
+            httpDataSourceFactorySpy);
+
+    PlaybackException exception =
+        new PlaybackException(null, null, PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW);
+    listeners.forEach(listener -> listener.onPlayerError(exception));
+
+    verify(fakeExoPlayer).seekToDefaultPosition();
+    verify(fakeExoPlayer).prepare();
   }
 }

--- a/packages/video_player/video_player_android/example/android/app/build.gradle
+++ b/packages/video_player/video_player_android/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace 'io.flutter.plugins.videoplayerexample'
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/video_player/video_player_android/example/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/video_player/video_player_android/example/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/video_player/video_player_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
+++ b/packages/video_player/video_player_android/example/android/app/src/androidTest/java/io/flutter/plugins/DartIntegrationTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * Annotation to aid repository tooling in determining if a test is
  * a native java unit test or a java class with a dart integration.
  *
- * See: https://github.com/flutter/flutter/wiki/Plugin-Tests#enabling-android-ui-tests
+ * See: https://github.com/flutter/flutter/blob/master/docs/ecosystem/testing/Plugin-Tests.md#enabling-android-ui-tests
  * for more infomation.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/packages/video_player/video_player_android/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
+++ b/packages/video_player/video_player_android/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
@@ -45,6 +45,6 @@ public class FlutterActivityTest {
 
     engine.destroy();
     verify(videoPlayerPlugin, times(1)).onDetachedFromEngine(pluginBindingCaptor.capture());
-    verify(videoPlayerPlugin, times(1)).initialize();
+    verify(videoPlayerPlugin, times(1)).onDestroy();
   }
 }

--- a/packages/video_player/video_player_android/example/android/build.gradle
+++ b/packages/video_player/video_player_android/example/android/build.gradle
@@ -11,6 +11,12 @@ buildscript {
 
 allprojects {
     repositories {
+        // See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
+        def artifactRepoKey = 'ARTIFACT_HUB_REPOSITORY'
+        if (System.getenv().containsKey(artifactRepoKey)) {
+            println "Using artifact hub"
+            maven { url System.getenv(artifactRepoKey) }
+        }
         google()
         mavenCentral()
     }
@@ -39,9 +45,9 @@ gradle.projectsEvaluated {
 
             // Workaround for several warnings when building
             // that the above turns into errors, coming from
-            // org.checkerframework.checker.nullness.qual and 
+            // org.checkerframework.checker.nullness.qual and
             // com.google.errorprone.annotations:
-            // 
+            //
             //   warning: Cannot find annotation method 'value()' in type
             //   'EnsuresNonNull': class file for
             //   org.checkerframework.checker.nullness.qual.EnsuresNonNull not found

--- a/packages/video_player/video_player_android/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/video_player/video_player_android/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/packages/video_player/video_player_android/example/android/settings.gradle
+++ b/packages/video_player/video_player_android/example/android/settings.gradle
@@ -13,3 +13,16 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+// See https://github.com/flutter/flutter/blob/master/docs/ecosystem/Plugins-and-Packages-repository-structure.md#gradle-structure for more info.
+buildscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.1"
+  }
+}
+apply plugin: "com.google.cloud.artifactregistry.gradle-plugin"

--- a/packages/video_player/video_player_android/example/lib/main.dart
+++ b/packages/video_player/video_player_android/example/lib/main.dart
@@ -181,9 +181,9 @@ class _ControlsOverlay extends StatelessWidget {
           reverseDuration: const Duration(milliseconds: 200),
           child: controller.value.isPlaying
               ? const SizedBox.shrink()
-              : Container(
+              : const ColoredBox(
                   color: Colors.black26,
-                  child: const Center(
+                  child: Center(
                     child: Icon(
                       Icons.play_arrow,
                       color: Colors.white,

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -222,25 +222,21 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
           asset: dataSource,
           package: package,
         );
-        break;
       case DataSourceType.network:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.network,
           uri: dataSource,
         );
-        break;
       case DataSourceType.file:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.file,
           uri: dataSource,
         );
-        break;
       case DataSourceType.contentUri:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.contentUri,
           uri: dataSource,
         );
-        break;
     }
 
     _textureId = (await _platform.create(dataSourceDescription)) ??
@@ -260,26 +256,16 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
           _platform.setVolume(_textureId, 1.0);
           _platform.setLooping(_textureId, true);
           _applyPlayPause();
-          break;
         case VideoEventType.completed:
           pause().then((void pauseResult) => seekTo(value.duration));
-          break;
         case VideoEventType.bufferingUpdate:
           value = value.copyWith(buffered: event.buffered);
-          break;
         case VideoEventType.bufferingStart:
           value = value.copyWith(isBuffering: true);
-          break;
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
-          break;
         case VideoEventType.isPlayingStateUpdate:
           value = value.copyWith(isPlaying: event.isPlaying);
-          break;
-        case VideoEventType.play:
-        case VideoEventType.pause:
-        case VideoEventType.startedPictureInPicture:
-        case VideoEventType.stoppedPictureInPicture:
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the video_player plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ^3.4.0
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -53,7 +53,6 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
         break;
       case DataSourceType.contentUri:
         uri = dataSource.uri;
-        break;
     }
     final CreateMessage message = CreateMessage(
       asset: asset,

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -97,6 +97,7 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
      message.videoProducer = config.videoProducer;
      message.videoEncodingVariant = config.videoEncodingVariant;
      message.videoCdn = config.videoCdn;
+     message.viewerPlanStatus = config.viewerPlanStatus;
 
      return _api.setupMux(message);
    }

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -292,6 +292,7 @@ class MuxConfigMessage {
     this.videoProducer,
     this.videoEncodingVariant,
     this.videoCdn,
+    this.viewerPlanStatus,
   });
 
   int? textureId;
@@ -336,6 +337,8 @@ class MuxConfigMessage {
 
   String? videoCdn;
 
+  String? viewerPlanStatus;
+
   Object encode() {
     return <Object?>[
       textureId,
@@ -359,6 +362,7 @@ class MuxConfigMessage {
       videoProducer,
       videoEncodingVariant,
       videoCdn,
+      viewerPlanStatus,
     ];
   }
 
@@ -386,6 +390,7 @@ class MuxConfigMessage {
       videoProducer: result[18] as String?,
       videoEncodingVariant: result[19] as String?,
       videoCdn: result[20] as String?,
+      viewerPlanStatus: result[21] as String?,
     );
   }
 }

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -616,8 +616,6 @@ class AndroidVideoPlayerApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyList.length > 1) {
-      debugPrint('error code: ${replyList[0] as String}');
-      debugPrint('error message: ${replyList[1] as String}');
       throw PlatformException(
         code: replyList[0]! as String,
         message: replyList[1] as String?,

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -8,7 +8,7 @@
 import 'dart:async';
 import 'dart:typed_data' show Float64List, Int32List, Int64List, Uint8List;
 
-import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
+import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer, debugPrint;
 import 'package:flutter/services.dart';
 
 class TextureMessage {
@@ -467,8 +467,7 @@ class AndroidVideoPlayerApi {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.initialize', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -612,6 +611,8 @@ class AndroidVideoPlayerApi {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyList.length > 1) {
+      debugPrint('error code: ${replyList[0] as String}');
+      debugPrint('error message: ${replyList[1] as String}');
       throw PlatformException(
         code: replyList[0]! as String,
         message: replyList[1] as String?,

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -94,6 +94,7 @@ class MuxConfigMessage {
   String? videoProducer;
   String? videoEncodingVariant;
   String? videoCdn;
+  String? viewerPlanStatus;
 }
 
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,11 +2,11 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.9
+version: 2.5.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ^3.4.0
+  flutter: ">=3.22.0"
 
 flutter:
   plugin:
@@ -32,3 +32,7 @@ dev_dependencies:
 dependency_overrides:
   video_player_platform_interface:
     path: ../../video_player/video_player_platform_interface
+
+topics:
+  - video
+  - video-player

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(a14n): remove this import once Flutter 3.1 or later reaches stable (including flutter/flutter#106316)
-// ignore: unnecessary_import
-import 'dart:ui';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:video_player_android/src/messages.g.dart';
@@ -247,16 +243,15 @@ void main() {
 
     test('videoEventsFor', () async {
       const String mockChannel = 'flutter.io/videoPlayer/videoEvents123';
-      _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-          .defaultBinaryMessenger
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMessageHandler(
         mockChannel,
         (ByteData? message) async {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
           if (methodCall.method == 'listen') {
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -268,8 +263,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -282,8 +277,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -292,8 +287,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -306,8 +301,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -316,8 +311,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -326,8 +321,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -337,8 +332,8 @@ void main() {
                     }),
                     (ByteData? data) {});
 
-            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
-                .defaultBinaryMessenger
+            await TestDefaultBinaryMessengerBinding
+                .instance.defaultBinaryMessenger
                 .handlePlatformMessage(
                     mockChannel,
                     const StandardMethodCodec()
@@ -398,9 +393,3 @@ void main() {
     });
   });
 }
-
-/// This allows a value of type T or T? to be treated as a value of type T?.
-///
-/// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` on the stable branch.
-T? _ambiguate<T>(T? value) => value;

--- a/packages/video_player/video_player_android/test/test_api.g.dart
+++ b/packages/video_player/video_player_android/test/test_api.g.dart
@@ -77,7 +77,8 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
 }
 
 abstract class TestHostVideoPlayerApi {
-  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding => TestDefaultBinaryMessengerBinding.instance;
+  static TestDefaultBinaryMessengerBinding? get _testBinaryMessengerBinding =>
+      TestDefaultBinaryMessengerBinding.instance;
   static const MessageCodec<Object?> codec = _TestHostVideoPlayerApiCodec();
 
   void initialize();
@@ -112,9 +113,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.initialize', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           // ignore message
           api.initialize();
           return <Object?>[];
@@ -126,9 +130,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.create', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.create was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -145,9 +152,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.dispose', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.dispose was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -164,9 +174,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setLooping', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setLooping was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -183,9 +196,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setVolume', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setVolume was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -202,9 +218,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setPlaybackSpeed', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setPlaybackSpeed was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -221,9 +240,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.play', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.play was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -240,9 +262,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.position', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.position was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -259,9 +284,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.seekTo', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.seekTo was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -278,9 +306,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.pause', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.pause was null.');
           final List<Object?> args = (message as List<Object?>?)!;
@@ -297,9 +328,12 @@ abstract class TestHostVideoPlayerApi {
           'dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setMixWithOthers', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, null);
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel, null);
       } else {
-        _testBinaryMessengerBinding!.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(channel, (Object? message) async {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(channel,
+                (Object? message) async {
           assert(message != null,
           'Argument for dev.flutter.pigeon.video_player_android.AndroidVideoPlayerApi.setMixWithOthers was null.');
           final List<Object?> args = (message as List<Object?>?)!;

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -839,10 +839,22 @@ NSNumber *_isLiveStream;
   // videoData.videoEncodingVariant = input.videoEncodingVariant;
   // videoData.videoCdn = input.videoCdn;
 
+  MUXSDKCustomerViewerData* viewerData = [MUXSDKCustomerViewerData new];
+  viewerData.viewerPlanStatus = input.viewerPlanStatus; // 視聴プラン OneTimePlan or SubscriptionPlan
+
+  // MUXSDKCustomerData* customerData = [MUXSDKCustomerData new];
+  // customerData.customerPlayerData = playerData;
+  // customerData.customerVideoData = videoData;
+  // customerData.customerViewerData = viewerData;
+  MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:playerData
+                                                                                videoData:videoData
+                                                                                 viewData:nil
+                                                                               customData:nil
+                                                                               viewerData:viewerData];
+
   [MUXSDKStats monitorAVPlayerViewController:playerViewController
     withPlayerName:input.playerName
-    playerData:playerData
-    videoData:videoData
+    customerData:customerData
   ];
 }
 

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
@@ -124,7 +124,8 @@ NS_ASSUME_NONNULL_BEGIN
     videoStreamType:(nullable NSString *)videoStreamType
     videoProducer:(nullable NSString *)videoProducer
     videoEncodingVariant:(nullable NSString *)videoEncodingVariant
-    videoCdn:(nullable NSString *)videoCdn;
+    videoCdn:(nullable NSString *)videoCdn
+    viewerPlanStatus:(nullable NSString *)viewerPlanStatus;
 @property(nonatomic, strong, nullable) NSNumber * textureId;
 @property(nonatomic, copy, nullable) NSString * envKey;
 @property(nonatomic, copy, nullable) NSString * playerName;
@@ -146,6 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nullable) NSString * videoProducer;
 @property(nonatomic, copy, nullable) NSString * videoEncodingVariant;
 @property(nonatomic, copy, nullable) NSString * videoCdn;
+@property(nonatomic, copy, nullable) NSString * viewerPlanStatus;
 @end
 
 @interface FLTAutomaticallyStartsPictureInPictureMessage : NSObject

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
@@ -347,7 +347,8 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     videoStreamType:(nullable NSString *)videoStreamType
     videoProducer:(nullable NSString *)videoProducer
     videoEncodingVariant:(nullable NSString *)videoEncodingVariant
-    videoCdn:(nullable NSString *)videoCdn {
+    videoCdn:(nullable NSString *)videoCdn
+    viewerPlanStatus:(nullable NSString *)viewerPlanStatus {
   FLTMuxConfigMessage* pigeonResult = [[FLTMuxConfigMessage alloc] init];
   pigeonResult.textureId = textureId;
   pigeonResult.envKey = envKey;
@@ -370,6 +371,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.videoProducer = videoProducer;
   pigeonResult.videoEncodingVariant = videoEncodingVariant;
   pigeonResult.videoCdn = videoCdn;
+  pigeonResult.viewerPlanStatus = viewerPlanStatus;
   return pigeonResult;
 }
 + (FLTMuxConfigMessage *)fromList:(NSArray *)list {
@@ -395,6 +397,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.videoProducer = GetNullableObjectAtIndex(list, 18);
   pigeonResult.videoEncodingVariant = GetNullableObjectAtIndex(list, 19);
   pigeonResult.videoCdn = GetNullableObjectAtIndex(list, 20);
+  pigeonResult.viewerPlanStatus = GetNullableObjectAtIndex(list, 21);
   return pigeonResult;
 }
 + (nullable FLTMuxConfigMessage *)nullableFromList:(NSArray *)list {
@@ -423,6 +426,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     (self.videoProducer ?: [NSNull null]),
     (self.videoEncodingVariant ?: [NSNull null]),
     (self.videoCdn ?: [NSNull null]),
+    (self.viewerPlanStatus ?: [NSNull null]),
   ];
 }
 @end

--- a/packages/video_player/video_player_avfoundation/ios/video_player_avfoundation.podspec
+++ b/packages/video_player/video_player_avfoundation/ios/video_player_avfoundation.podspec
@@ -16,7 +16,7 @@ Downloaded by pub (not CocoaPods).
   s.documentation_url = 'https://pub.dev/packages/video_player'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'Mux-Stats-AVPlayer', '~>3.0'
+  s.dependency 'Mux-Stats-AVPlayer', '~>4.0'
   s.dependency 'Flutter'
 
   s.platform = :ios, '11.0'

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -55,6 +55,7 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
     // message.videoProducer = config.videoProducer;
     // message.videoEncodingVariant = config.videoEncodingVariant;
     // message.videoCdn = config.videoCdn;
+    message.viewerPlanStatus = config.viewerPlanStatus;
 
     return _api.setupMux(message);
   }

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -246,6 +246,7 @@ class MuxConfigMessage {
     this.videoProducer,
     this.videoEncodingVariant,
     this.videoCdn,
+    this.viewerPlanStatus,
   });
 
   int? textureId;
@@ -290,6 +291,8 @@ class MuxConfigMessage {
 
   String? videoCdn;
 
+  String? viewerPlanStatus;
+
   Object encode() {
     return <Object?>[
       textureId,
@@ -313,6 +316,7 @@ class MuxConfigMessage {
       videoProducer,
       videoEncodingVariant,
       videoCdn,
+      viewerPlanStatus,
     ];
   }
 
@@ -340,6 +344,7 @@ class MuxConfigMessage {
       videoProducer: result[18] as String?,
       videoEncodingVariant: result[19] as String?,
       videoCdn: result[20] as String?,
+      viewerPlanStatus: result[21] as String?,
     );
   }
 }

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -91,6 +91,7 @@ class MuxConfigMessage {
   String? videoProducer;
   String? videoEncodingVariant;
   String? videoCdn;
+  String? viewerPlanStatus;
 }
 
 class AutomaticallyStartsPictureInPictureMessage {

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -468,6 +468,7 @@ class MuxConfig {
     this.videoProducer,
     this.videoEncodingVariant,
     this.videoCdn,
+    this.viewerPlanStatus,
   });
 
   final String envKey;
@@ -490,6 +491,7 @@ class MuxConfig {
   final String? videoProducer;
   final String? videoEncodingVariant;
   final String? videoCdn;
+  final String? viewerPlanStatus;
 }
 
 enum MuxVideoStreamType {


### PR DESCRIPTION
MUXに送信するパラメータに`viewerPlanStatus`を追加し、視聴プラン（`OneTimePlan` or `SubscriptionPlan`）を記録できるようにした
https://linear.app/glucose/issue/SRS-576

App側の修正：https://github.com/glucoseinc/shirasu-app/pull/408

---

Android側は、`mux-stats-sdk-exoplayer`からは送れなかったので、`mux-stats-sdk-media3`に移行した。
それに伴い、exoplayer2からmedia3に移行した。
補足として、下記のように移行が推奨されていたのでいずれ必要なことではあった。
> 現在スタンドアロンの `com.google.android.exoplayer2` ライブラリと `androidx.media` を使用しているアプリは、`androidx.media3` に移行する必要があります。
> https://developer.android.com/media/media3/exoplayer/migration-guide?hl=ja

media3への移行作業は`flutter-packages`のフォーク元が既に対応していたので取り込むことで対応した。
その後、弊社の独自拡張分を手作業で修正した。
具体的な手順は以下。
```
# 1. 作業用ブランチを切る
git checkout -b media3

# 2. フォーク元から取り込みたい部分（`video_player_android/`）だけを取り込む
git checkout upstream/main -- packages/video_player/video_player_android

# 3. 弊社側の最新コミット（`5bb58fc`）でrebaseして、弊社側の追加分を加え直す
# ※ 2. でファイルが丸々上書きされて弊社分が消えるので、rebaseして加える必要がある
git rebase 5bb58fc

# (ここまででexoplayerからmedia3への移行は終了)

# 4. `mux-stats-sdk-exoplayer`から`mux-stats-sdk-media3`に移行する
手作業で当該パッケージ使用部分を書き換える
```
この取り込み作業のコミット：**chore: exoplayerからmedia3に移行** `f06b94f`

この手順のあと、`viewer_plan_status`を送信するコードを追加した。

---

MUXのパッケージ更新に伴い、`videoData.setVideoCdn`がdeprecatedになっていたので削除した。

iOS側はパッケージのバージョンアップ以外の作業は不要だった。