### PR TITLE
[video_player_avfoundation] [SRS-2824] keyWindow/rootViewController nil時のSentryログを追加

### DIFF
--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -6,6 +6,7 @@
 #import "FLTVideoPlayerPlugin_Test.h"
 
 #import <AVFoundation/AVFoundation.h>
+#import <Sentry/Sentry.h>
 #import <AVKit/AVKit.h>
 #import <GLKit/GLKit.h>
 #import "AVAssetTrackUtils.h"
@@ -190,8 +191,13 @@ NS_INLINE UIViewController *rootViewController(void) {
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   // TODO: (hellohuanlin) Provide a non-deprecated codepath. See
   // https://github.com/flutter/flutter/issues/104117
-  return UIApplication.sharedApplication.keyWindow.rootViewController;
+  UIWindow *keyWindow = UIApplication.sharedApplication.keyWindow;
 #pragma clang diagnostic pop
+  if (keyWindow == nil) {
+    [SentrySDK captureMessage:@"[video_player] keyWindow is nil: UIScene environment may prevent playerLayer from being added (encrypted video blank bug)"
+                    withLevel:kSentryLevelWarning];
+  }
+  return keyWindow.rootViewController;
 }
 
 - (AVMutableVideoComposition *)getVideoCompositionWithTransform:(CGAffineTransform)transform
@@ -279,7 +285,12 @@ NS_INLINE UIViewController *rootViewController(void) {
   // Picture-in-picture will show a placeholder over other widgets when video_player is used in a
   // ScrollView, PageView or in a widget that changes location.
   _playerLayer.opacity = 0.001;
-  [rootViewController().view.layer addSublayer:_playerLayer];
+  UIViewController *vc = rootViewController();
+  if (vc == nil) {
+    [SentrySDK captureMessage:@"[video_player] rootViewController is nil: playerLayer not added, encrypted video will not play"
+                    withLevel:kSentryLevelError];
+  }
+  [vc.view.layer addSublayer:_playerLayer];
 
   _player.allowsExternalPlayback = NO;
 


### PR DESCRIPTION
iOS 26 + UIScene 有効環境で `keyWindow` が nil を返す問題の調査のため、Sentry ログを追加する。

## 背景

SRS-2567 で `UIApplicationSceneManifest` を追加して UIScene ライフサイクルを有効化したことにより、iOS 26 環境で `UIApplication.sharedApplication.keyWindow` が nil を返す可能性がある。

`FLTVideoPlayerPlugin.m` の `rootViewController()` はこの `keyWindow` を使っており、nil の場合 `addSublayer:_playerLayer` が no-op となり、暗号化動画の再生が無音・無映像になる（iOS 16 の blank video バグ回避策が機能しなくなる）可能性がある。
シラスアプリで配信が見れない問い合わせがあり、上記の問題が原因として可能性があるため、Sentryログを仕込む

## 変更内容

- `rootViewController()` 内で `keyWindow == nil` を検知し、Sentry に warning を送出
- `initWithPlayerItem:` 内で `rootViewController()` が nil の場合に Sentry に error を送出

## 関連

- shirasu-app: glucoseinc/shirasu-app#484（このコミットを参照）
- SRS-2824

## 申し送り
親ブランチである`fix/app-build`はPRが出ておらず、ブランチが切られた状態で放置されているので、どこかでPR出してマージする必要がある