### PR TITLE
fix: [SRS-2824] SentryをHybridSDK ~>8.0に変更（バージョン競合解消）

### DIFF
--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -6,7 +6,7 @@
 #import "FLTVideoPlayerPlugin_Test.h"
 
 #import <AVFoundation/AVFoundation.h>
-#import <Sentry/Sentry.h>
+@import Sentry;
 #import <AVKit/AVKit.h>
 #import <GLKit/GLKit.h>
 #import "AVAssetTrackUtils.h"
@@ -195,7 +195,7 @@ NS_INLINE UIViewController *rootViewController(void) {
 #pragma clang diagnostic pop
   if (keyWindow == nil) {
     [SentrySDK captureMessage:@"[video_player] keyWindow is nil: UIScene environment may prevent playerLayer from being added (encrypted video blank bug)"
-                    withLevel:kSentryLevelWarning];
+               withScopeBlock:^(SentryScope *scope) { [scope setLevel:kSentryLevelWarning]; }];
   }
   return keyWindow.rootViewController;
 }
@@ -288,7 +288,7 @@ NS_INLINE UIViewController *rootViewController(void) {
   UIViewController *vc = rootViewController();
   if (vc == nil) {
     [SentrySDK captureMessage:@"[video_player] rootViewController is nil: playerLayer not added, encrypted video will not play"
-                    withLevel:kSentryLevelError];
+               withScopeBlock:^(SentryScope *scope) { [scope setLevel:kSentryLevelError]; }];
   }
   [vc.view.layer addSublayer:_playerLayer];
 

--- a/packages/video_player/video_player_avfoundation/ios/video_player_avfoundation.podspec
+++ b/packages/video_player/video_player_avfoundation/ios/video_player_avfoundation.podspec
@@ -18,6 +18,7 @@ Downloaded by pub (not CocoaPods).
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Mux-Stats-AVPlayer', '~>4.0'
   s.dependency 'Flutter'
+  s.dependency 'Sentry/HybridSDK', '~> 8.0'
 
   s.platform = :ios, '11.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }


### PR DESCRIPTION
## 概要

`video_player_avfoundation` の podspec に `s.dependency 'Sentry/HybridSDK', '~> 8.0'` を追加。

`FLTVideoPlayerPlugin.m` で `#import <Sentry/Sentry.h>` を使用しているが、podspec に依存が宣言されておらずビルドエラーになっていたため修正。

バージョンは `sentry_flutter` が要求する `HybridSDK 8.58.0` と競合しないよう `~> 8.0` で固定。